### PR TITLE
Migrate navigation to go_router

### DIFF
--- a/lib/common/app_router.dart
+++ b/lib/common/app_router.dart
@@ -1,0 +1,231 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../view/home/activity_tracker_view.dart';
+import '../view/home/finished_workout_view.dart';
+import '../view/home/notification_view.dart';
+import '../view/login/complete_profile_view.dart';
+import '../view/login/login_view.dart';
+import '../view/login/signup_view.dart';
+import '../view/login/welcome_view.dart';
+import '../view/login/what_your_goal_view.dart';
+import '../view/main_tab/main_tab_view.dart';
+import '../view/main_tab/select_view.dart';
+import '../view/meal_planner/food_info_details_view.dart';
+import '../view/meal_planner/meal_food_details_view.dart';
+import '../view/meal_planner/meal_planner_view.dart';
+import '../view/meal_planner/meal_schedule_view.dart';
+import '../view/on_boarding/on_boarding_view.dart';
+import '../view/photo_progress/comparison_view.dart';
+import '../view/photo_progress/photo_progress_view.dart';
+import '../view/photo_progress/result_view.dart';
+import '../view/profile/profile_view.dart';
+import '../view/sleep_tracker/sleep_add_alarm_view.dart';
+import '../view/sleep_tracker/sleep_schedule_view.dart';
+import '../view/sleep_tracker/sleep_tracker_view.dart';
+import '../view/workout_tracker/add_schedule_view.dart';
+import '../view/workout_tracker/exercises_stpe_details.dart';
+import '../view/workout_tracker/workout_schedule_view.dart';
+import '../view/workout_tracker/workout_tracker_view.dart';
+import '../view/workout_tracker/workour_detail_view.dart';
+
+class AppRoute {
+  static const String main = '/';
+  static const String onboarding = '/onboarding';
+  static const String login = '/login';
+  static const String signUp = '/sign-up';
+  static const String completeProfile = '/complete-profile';
+  static const String goal = '/goal';
+  static const String welcome = '/welcome';
+  static const String activityTracker = '/activity-tracker';
+  static const String notification = '/notification';
+  static const String finishedWorkout = '/finished-workout';
+  static const String workoutTracker = '/workout-tracker';
+  static const String workoutSchedule = '/workout-schedule';
+  static const String addWorkoutSchedule = '/workout-schedule/add';
+  static const String workoutDetail = '/workout-detail';
+  static const String exerciseSteps = '/exercise-steps';
+  static const String mealPlanner = '/meal-planner';
+  static const String mealSchedule = '/meal-planner/schedule';
+  static const String mealFoodDetails = '/meal-planner/food-details';
+  static const String foodInfo = '/meal-planner/food-info';
+  static const String photoProgress = '/photo-progress';
+  static const String photoComparison = '/photo-progress/comparison';
+  static const String photoResult = '/photo-progress/result';
+  static const String sleepTracker = '/sleep-tracker';
+  static const String sleepSchedule = '/sleep-tracker/schedule';
+  static const String sleepAddAlarm = '/sleep-tracker/add-alarm';
+}
+
+class AppRouter {
+  static final GoRouter router = GoRouter(
+    initialLocation: AppRoute.main,
+    routes: [
+      GoRoute(
+        path: AppRoute.main,
+        builder: (context, state) => const MainTabView(),
+      ),
+      GoRoute(
+        path: AppRoute.onboarding,
+        builder: (context, state) => const OnBoardingView(),
+      ),
+      GoRoute(
+        path: AppRoute.login,
+        builder: (context, state) => const LoginView(),
+      ),
+      GoRoute(
+        path: AppRoute.signUp,
+        builder: (context, state) => const SignUpView(),
+      ),
+      GoRoute(
+        path: AppRoute.completeProfile,
+        builder: (context, state) => const CompleteProfileView(),
+      ),
+      GoRoute(
+        path: AppRoute.goal,
+        builder: (context, state) => const WhatYourGoalView(),
+      ),
+      GoRoute(
+        path: AppRoute.welcome,
+        builder: (context, state) => const WelcomeView(),
+      ),
+      GoRoute(
+        path: AppRoute.activityTracker,
+        builder: (context, state) => const ActivityTrackerView(),
+      ),
+      GoRoute(
+        path: AppRoute.notification,
+        builder: (context, state) => const NotificationView(),
+      ),
+      GoRoute(
+        path: AppRoute.finishedWorkout,
+        builder: (context, state) => const FinishedWorkoutView(),
+      ),
+      GoRoute(
+        path: AppRoute.workoutTracker,
+        builder: (context, state) => const WorkoutTrackerView(),
+      ),
+      GoRoute(
+        path: AppRoute.workoutSchedule,
+        builder: (context, state) => const WorkoutScheduleView(),
+      ),
+      GoRoute(
+        path: AppRoute.addWorkoutSchedule,
+        builder: (context, state) {
+          final extra = state.extra;
+          if (extra is! DateTime) {
+            throw ArgumentError('AddScheduleView requires a DateTime extra.');
+          }
+          return AddScheduleView(date: extra);
+        },
+      ),
+      GoRoute(
+        path: AppRoute.workoutDetail,
+        builder: (context, state) {
+          final extra = state.extra;
+          if (extra is! Map) {
+            throw ArgumentError('WorkoutDetailView requires a Map extra.');
+          }
+          return WorkoutDetailView(dObj: Map<String, dynamic>.from(extra as Map));
+        },
+      ),
+      GoRoute(
+        path: AppRoute.exerciseSteps,
+        builder: (context, state) {
+          final extra = state.extra;
+          if (extra is! Map) {
+            throw ArgumentError('ExercisesStepDetails requires a Map extra.');
+          }
+          return ExercisesStepDetails(eObj: Map<String, dynamic>.from(extra as Map));
+        },
+      ),
+      GoRoute(
+        path: AppRoute.mealPlanner,
+        builder: (context, state) => const MealPlannerView(),
+      ),
+      GoRoute(
+        path: AppRoute.mealSchedule,
+        builder: (context, state) => const MealScheduleView(),
+      ),
+      GoRoute(
+        path: AppRoute.mealFoodDetails,
+        builder: (context, state) {
+          final extra = state.extra;
+          if (extra is! Map) {
+            throw ArgumentError('MealFoodDetailsView requires a Map extra.');
+          }
+          return MealFoodDetailsView(eObj: Map<String, dynamic>.from(extra as Map));
+        },
+      ),
+      GoRoute(
+        path: AppRoute.foodInfo,
+        builder: (context, state) {
+          final extra = state.extra;
+          if (extra is! Map) {
+            throw ArgumentError('FoodInfoDetailsView requires a Map extra.');
+          }
+          final map = Map<String, dynamic>.from(extra as Map);
+          final meal = map['meal'];
+          final food = map['food'];
+          if (meal is! Map || food is! Map) {
+            throw ArgumentError('FoodInfoDetailsView requires meal and food Map extras.');
+          }
+          return FoodInfoDetailsView(
+            mObj: Map<String, dynamic>.from(meal),
+            dObj: Map<String, dynamic>.from(food),
+          );
+        },
+      ),
+      GoRoute(
+        path: AppRoute.photoProgress,
+        builder: (context, state) => const PhotoProgressView(),
+      ),
+      GoRoute(
+        path: AppRoute.photoComparison,
+        builder: (context, state) => const ComparisonView(),
+      ),
+      GoRoute(
+        path: AppRoute.photoResult,
+        builder: (context, state) {
+          final extra = state.extra;
+          if (extra is! Map) {
+            throw ArgumentError('ResultView requires a Map extra.');
+          }
+          final map = Map<String, dynamic>.from(extra as Map);
+          final date1 = map['date1'];
+          final date2 = map['date2'];
+          if (date1 is! DateTime || date2 is! DateTime) {
+            throw ArgumentError('ResultView requires DateTime extras.');
+          }
+          return ResultView(date1: date1, date2: date2);
+        },
+      ),
+      GoRoute(
+        path: AppRoute.sleepTracker,
+        builder: (context, state) => const SleepTrackerView(),
+      ),
+      GoRoute(
+        path: AppRoute.sleepSchedule,
+        builder: (context, state) => const SleepScheduleView(),
+      ),
+      GoRoute(
+        path: AppRoute.sleepAddAlarm,
+        builder: (context, state) {
+          final extra = state.extra;
+          if (extra is! DateTime) {
+            throw ArgumentError('SleepAddAlarmView requires a DateTime extra.');
+          }
+          return SleepAddAlarmView(date: extra);
+        },
+      ),
+      GoRoute(
+        path: '/profile',
+        builder: (context, state) => const ProfileView(),
+      ),
+      GoRoute(
+        path: '/select',
+        builder: (context, state) => const SelectView(),
+      ),
+    ],
+  );
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
+import 'package:aigymbuddy/common/app_router.dart';
 import 'package:aigymbuddy/common/color_extension.dart';
-import 'package:aigymbuddy/view/main_tab/main_tab_view.dart';
 import 'package:flutter/material.dart';
 
 void main() {
@@ -12,7 +12,7 @@ class MyApp extends StatelessWidget {
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return MaterialApp.router(
       title: 'AI Gym Buddy',
       debugShowCheckedModeBanner: false,
       theme: ThemeData(
@@ -34,7 +34,7 @@ class MyApp extends StatelessWidget {
         primaryColor: TColor.primaryColor1,
         fontFamily: "Poppins"
       ),
-      home: const MainTabView(),
+      routerConfig: AppRouter.router,
     );
   }
 }

--- a/lib/view/home/activity_tracker_view.dart
+++ b/lib/view/home/activity_tracker_view.dart
@@ -1,5 +1,6 @@
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../common/color_extension.dart';
 import '../../common_widget/latest_activity_row.dart';
@@ -38,7 +39,7 @@ class _ActivityTrackerViewState extends State<ActivityTrackerView> {
         centerTitle: true,
         elevation: 0,
         leading: InkWell(
-          onTap: () => Navigator.pop(context),
+          onTap: () => context.pop(),
           child: Container(
             margin: const EdgeInsets.all(8),
             height: 40,

--- a/lib/view/home/finished_workout_view.dart
+++ b/lib/view/home/finished_workout_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../common/color_extension.dart';
 import '../../common_widget/round_button.dart';
@@ -74,7 +75,7 @@ class _FinishedWorkoutViewState extends State<FinishedWorkoutView> {
                RoundButton(
                   title: "Back To Home",
                   onPressed: () {
-                    Navigator.pop(context);
+                    context.pop();
                   }),
 
                  const SizedBox(

--- a/lib/view/home/home_view.dart
+++ b/lib/view/home/home_view.dart
@@ -8,9 +8,8 @@ import 'package:flutter/material.dart';
 import 'package:simple_animation_progress_bar/simple_animation_progress_bar.dart';
 import 'package:simple_circular_progress_bar/simple_circular_progress_bar.dart';
 import '../../common/color_extension.dart';
-import 'activity_tracker_view.dart';
-import 'finished_workout_view.dart';
-import 'notification_view.dart';
+import 'package:aigymbuddy/common/app_router.dart';
+import 'package:go_router/go_router.dart';
 
 class HomeView extends StatefulWidget {
   const HomeView({super.key});
@@ -150,12 +149,7 @@ class _HomeViewState extends State<HomeView> {
                     ),
                     IconButton(
                       onPressed: () {
-                        Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder: (context) => const NotificationView(),
-                          ),
-                        );
+                        context.push(AppRoute.notification);
                       },
                       icon: Image.asset(
                         "assets/img/notification_active.png",
@@ -268,12 +262,7 @@ class _HomeViewState extends State<HomeView> {
                           fontSize: 12,
                           fontWeight: FontWeight.w400,
                           onPressed: () {
-                            Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                builder: (context) => const ActivityTrackerView(),
-                              ),
-                            );
+                            context.push(AppRoute.activityTracker);
                           },
                         ),
                       ),
@@ -884,10 +873,7 @@ class _HomeViewState extends State<HomeView> {
                     final wObj = lastWorkoutArr[index];
                     return InkWell(
                       onTap: () {
-                        Navigator.push(
-                          context,
-                          MaterialPageRoute(builder: (context) => const FinishedWorkoutView()),
-                        );
+                        context.push(AppRoute.finishedWorkout);
                       },
                       child: WorkoutRow(wObj: wObj),
                     );

--- a/lib/view/home/notification_view.dart
+++ b/lib/view/home/notification_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../common/color_extension.dart';
 import '../../common_widget/notification_row.dart';
@@ -29,7 +30,7 @@ class _NotificationViewState extends State<NotificationView> {
         elevation: 0,
         leading: InkWell(
           onTap: () {
-            Navigator.pop(context);
+            context.pop();
           },
           child: Container(
             margin: const EdgeInsets.all(8),

--- a/lib/view/login/complete_profile_view.dart
+++ b/lib/view/login/complete_profile_view.dart
@@ -1,6 +1,7 @@
+import 'package:aigymbuddy/common/app_router.dart';
 import 'package:aigymbuddy/common/color_extension.dart';
-import 'package:aigymbuddy/view/login/what_your_goal_view.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../common_widget/round_button.dart';
 import '../../common_widget/round_textfield.dart';
@@ -181,11 +182,7 @@ class _CompleteProfileViewState extends State<CompleteProfileView> {
                       RoundButton(
                           title: "Next >",
                           onPressed: () {
-                            Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                    builder: (context) =>
-                                        const WhatYourGoalView()));
+                            context.push(AppRoute.goal);
                           }),
                     ],
                   ),

--- a/lib/view/login/login_view.dart
+++ b/lib/view/login/login_view.dart
@@ -1,8 +1,9 @@
+import 'package:aigymbuddy/common/app_router.dart';
 import 'package:aigymbuddy/common/color_extension.dart';
 import 'package:aigymbuddy/common_widget/round_button.dart';
 import 'package:aigymbuddy/common_widget/round_textfield.dart';
-import 'package:aigymbuddy/view/login/complete_profile_view.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 class LoginView extends StatefulWidget {
   const LoginView({super.key});
@@ -85,11 +86,7 @@ class _LoginViewState extends State<LoginView> {
                 RoundButton(
                     title: "Login",
                     onPressed: () {
-                      Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                              builder: (context) =>
-                                  const CompleteProfileView()));
+                      context.push(AppRoute.completeProfile);
                     }),
                 SizedBox(
                   height: media.width * 0.04,
@@ -171,7 +168,7 @@ class _LoginViewState extends State<LoginView> {
                 ),
                 TextButton(
                   onPressed: () {
-                    Navigator.pop(context);
+                    context.pop();
                   },
                   child: Row(
                     mainAxisSize: MainAxisSize.min,

--- a/lib/view/login/signup_view.dart
+++ b/lib/view/login/signup_view.dart
@@ -1,9 +1,9 @@
+import 'package:aigymbuddy/common/app_router.dart';
 import 'package:aigymbuddy/common/color_extension.dart';
 import 'package:aigymbuddy/common_widget/round_button.dart';
 import 'package:aigymbuddy/common_widget/round_textfield.dart';
-import 'package:aigymbuddy/view/login/complete_profile_view.dart';
-import 'package:aigymbuddy/view/login/login_view.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 class SignUpView extends StatefulWidget {
   const SignUpView({super.key});
@@ -110,9 +110,11 @@ class _SignUpViewState extends State<SignUpView> {
                 SizedBox(
                   height: media.width * 0.4,
                 ),
-                RoundButton(title: "Register", onPressed: () {
-                  Navigator.push(context, MaterialPageRoute(builder: (context) => const CompleteProfileView()  ));
-                }),
+                RoundButton(
+                    title: "Register",
+                    onPressed: () {
+                      context.push(AppRoute.completeProfile);
+                    }),
                 SizedBox(
                   height: media.width * 0.04,
                 ),
@@ -195,10 +197,7 @@ class _SignUpViewState extends State<SignUpView> {
                 ),
                 TextButton(
                   onPressed: () {
-                     Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                            builder: (context) => const LoginView()));
+                    context.push(AppRoute.login);
                   },
                   child: Row(
                     mainAxisSize: MainAxisSize.min,

--- a/lib/view/login/welcome_view.dart
+++ b/lib/view/login/welcome_view.dart
@@ -1,8 +1,9 @@
+import 'package:aigymbuddy/common/app_router.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../common/color_extension.dart';
 import '../../common_widget/round_button.dart';
-import '../main_tab/main_tab_view.dart';
 
 class WelcomeView extends StatefulWidget {
   const WelcomeView({super.key});
@@ -51,13 +52,10 @@ SizedBox(
               ),
              const Spacer(),
 
-               RoundButton(
+                  RoundButton(
                   title: "Go To Home",
                   onPressed: () {
-                    Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                            builder: (context) => const MainTabView()));
+                    context.go(AppRoute.main);
                   }),
                
             ],

--- a/lib/view/login/what_your_goal_view.dart
+++ b/lib/view/login/what_your_goal_view.dart
@@ -1,6 +1,7 @@
+import 'package:aigymbuddy/common/app_router.dart';
 import 'package:carousel_slider/carousel_slider.dart';
-import 'package:aigymbuddy/view/login/welcome_view.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../common/color_extension.dart';
 import '../../common_widget/round_button.dart';
@@ -134,10 +135,7 @@ class _WhatYourGoalViewState extends State<WhatYourGoalView> {
                 RoundButton(
                     title: "Confirm",
                     onPressed: () {
-                      Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                              builder: (context) => const WelcomeView()));
+                      context.push(AppRoute.welcome);
                     }),
               ],
             ),

--- a/lib/view/main_tab/select_view.dart
+++ b/lib/view/main_tab/select_view.dart
@@ -1,9 +1,7 @@
+import 'package:aigymbuddy/common/app_router.dart';
 import 'package:aigymbuddy/common_widget/round_button.dart';
-import 'package:aigymbuddy/view/meal_planner/meal_planner_view.dart';
-import 'package:aigymbuddy/view/workout_tracker/workout_tracker_view.dart';
 import 'package:flutter/material.dart';
-
-import '../sleep_tracker/sleep_tracker_view.dart';
+import 'package:go_router/go_router.dart';
 
 class SelectView extends StatelessWidget {
   const SelectView({super.key});
@@ -21,12 +19,7 @@ class SelectView extends StatelessWidget {
             RoundButton(
                 title: "Workout Tracker",
                 onPressed: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (context) => const WorkoutTrackerView(),
-                    ),
-                  );
+                  context.push(AppRoute.workoutTracker);
                 }),
 
                 const SizedBox(height: 15,),
@@ -34,12 +27,7 @@ class SelectView extends StatelessWidget {
                   RoundButton(
                 title: "Meal Planner",
                 onPressed: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (context) => const MealPlannerView(),
-                    ),
-                  );
+                  context.push(AppRoute.mealPlanner);
                 }),
 
                 const SizedBox(height: 15,),
@@ -47,12 +35,7 @@ class SelectView extends StatelessWidget {
                   RoundButton(
                 title: "Sleep Tracker",
                 onPressed: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (context) => const SleepTrackerView(),
-                    ),
-                  );
+                  context.push(AppRoute.sleepTracker);
                 })
           ],
         ),

--- a/lib/view/meal_planner/food_info_details_view.dart
+++ b/lib/view/meal_planner/food_info_details_view.dart
@@ -1,6 +1,7 @@
 import 'package:aigymbuddy/common/color_extension.dart';
 import 'package:aigymbuddy/common_widget/round_button.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:readmore/readmore.dart';
 
 import '../../common_widget/food_step_detail_row.dart';
@@ -69,7 +70,7 @@ class _FoodInfoDetailsViewState extends State<FoodInfoDetailsView> {
               elevation: 0,
               leading: InkWell(
                 onTap: () {
-                  Navigator.pop(context);
+                  context.pop();
                 },
                 child: Container(
                   margin: const EdgeInsets.all(8),

--- a/lib/view/meal_planner/meal_food_details_view.dart
+++ b/lib/view/meal_planner/meal_food_details_view.dart
@@ -1,12 +1,13 @@
 // lib/view/meal_planner/meal_food_details_view.dart
 
+import 'package:aigymbuddy/common/app_router.dart';
 import 'package:aigymbuddy/common_widget/meal_recommend_cell.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../common/color_extension.dart';
 import '../../common_widget/meal_category_cell.dart';
 import '../../common_widget/popular_meal_row.dart';
-import 'food_info_details_view.dart';
 
 class MealFoodDetailsView extends StatefulWidget {
   final Map<String, dynamic> eObj;
@@ -76,7 +77,7 @@ class _MealFoodDetailsViewState extends State<MealFoodDetailsView> {
         centerTitle: true,
         elevation: 0,
         leading: InkWell(
-          onTap: () => Navigator.pop(context),
+          onTap: () => context.pop(),
           child: Container(
             margin: const EdgeInsets.all(8),
             height: 40,
@@ -267,14 +268,12 @@ class _MealFoodDetailsViewState extends State<MealFoodDetailsView> {
                 final Map<String, dynamic> fObj = popularArr[index];
                 return InkWell(
                   onTap: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (context) => FoodInfoDetailsView(
-                          dObj: fObj,
-                          mObj: widget.eObj,
-                        ),
-                      ),
+                    context.push(
+                      AppRoute.foodInfo,
+                      extra: {
+                        'food': Map<String, dynamic>.from(fObj),
+                        'meal': Map<String, dynamic>.from(widget.eObj),
+                      },
                     );
                   },
                   child: PopularMealRow(mObj: fObj),

--- a/lib/view/meal_planner/meal_planner_view.dart
+++ b/lib/view/meal_planner/meal_planner_view.dart
@@ -1,14 +1,14 @@
 // lib/view/meal_planner/meal_planner_view.dart
 
+import 'package:aigymbuddy/common/app_router.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../common/color_extension.dart';
 import '../../common_widget/find_eat_cell.dart';
 import '../../common_widget/round_button.dart';
 import '../../common_widget/today_meal_row.dart';
-import 'meal_food_details_view.dart';
-import 'meal_schedule_view.dart';
 
 class MealPlannerView extends StatefulWidget {
   const MealPlannerView({super.key});
@@ -46,7 +46,7 @@ class _MealPlannerViewState extends State<MealPlannerView> {
         centerTitle: true,
         elevation: 0,
         leading: InkWell(
-          onTap: () => Navigator.pop(context),
+          onTap: () => context.pop(),
           child: Container(
             margin: const EdgeInsets.all(8),
             height: 40,
@@ -267,12 +267,7 @@ class _MealPlannerViewState extends State<MealPlannerView> {
                             fontSize: 12,
                             fontWeight: FontWeight.w400,
                             onPressed: () {
-                              Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                  builder: (context) => const MealScheduleView(),
-                                ),
-                              );
+                              context.push(AppRoute.mealSchedule);
                             },
                           ),
                         ),
@@ -369,11 +364,9 @@ class _MealPlannerViewState extends State<MealPlannerView> {
                   final fObj = findEatArr[index];
                   return InkWell(
                     onTap: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (context) => MealFoodDetailsView(eObj: fObj),
-                        ),
+                      context.push(
+                        AppRoute.mealFoodDetails,
+                        extra: Map<String, dynamic>.from(fObj),
                       );
                     },
                     child: FindEatCell(fObj: fObj, index: index),

--- a/lib/view/meal_planner/meal_schedule_view.dart
+++ b/lib/view/meal_planner/meal_schedule_view.dart
@@ -2,6 +2,7 @@
 
 import 'package:calendar_agenda/calendar_agenda.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 
 import '../../common/color_extension.dart';
@@ -79,7 +80,7 @@ class _MealScheduleViewState extends State<MealScheduleView> {
         centerTitle: true,
         elevation: 0,
         leading: InkWell(
-          onTap: () => Navigator.pop(context),
+          onTap: () => context.pop(),
           child: Container(
             margin: const EdgeInsets.all(8),
             alignment: Alignment.center,

--- a/lib/view/on_boarding/on_boarding_view.dart
+++ b/lib/view/on_boarding/on_boarding_view.dart
@@ -1,6 +1,7 @@
+import 'package:aigymbuddy/common/app_router.dart';
 import 'package:aigymbuddy/common_widget/on_boarding_page.dart';
-import 'package:aigymbuddy/view/login/signup_view.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../common/color_extension.dart';
 
@@ -110,7 +111,7 @@ class _OnBoardingViewState extends State<OnBoardingView> {
                       }else{
                         // Open Welcome Screen
                         print("Open Welcome Screen");
-                        Navigator.push(context, MaterialPageRoute(builder: (context) => const SignUpView() ));
+                        context.push(AppRoute.signUp);
                       }
                       
                   },),

--- a/lib/view/photo_progress/comparison_view.dart
+++ b/lib/view/photo_progress/comparison_view.dart
@@ -1,7 +1,8 @@
+import 'package:aigymbuddy/common/app_router.dart';
 import 'package:aigymbuddy/common_widget/icon_title_next_row.dart';
 import 'package:aigymbuddy/common_widget/round_button.dart';
-import 'package:aigymbuddy/view/photo_progress/result_view.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../common/color_extension.dart';
 
@@ -22,7 +23,7 @@ class _ComparisonViewState extends State<ComparisonView> {
         elevation: 0,
         leading: InkWell(
           onTap: () {
-            Navigator.pop(context);
+            context.pop();
           },
           child: Container(
             margin: const EdgeInsets.all(8),
@@ -90,14 +91,12 @@ class _ComparisonViewState extends State<ComparisonView> {
             RoundButton(
                 title: "Compare",
                 onPressed: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (context) => ResultView(
-                        date1: DateTime(2023, 5, 1),
-                        date2: DateTime(2023, 6, 1),
-                      ),
-                    ),
+                  context.push(
+                    AppRoute.photoResult,
+                    extra: {
+                      'date1': DateTime(2023, 5, 1),
+                      'date2': DateTime(2023, 6, 1),
+                    },
                   );
                 }),
             const SizedBox(

--- a/lib/view/photo_progress/photo_progress_view.dart
+++ b/lib/view/photo_progress/photo_progress_view.dart
@@ -1,8 +1,9 @@
+import 'package:aigymbuddy/common/app_router.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../common/color_extension.dart';
 import '../../common_widget/round_button.dart';
-import 'comparison_view.dart';
 
 class PhotoProgressView extends StatefulWidget {
   const PhotoProgressView({super.key});
@@ -215,13 +216,7 @@ class _PhotoProgressViewState extends State<PhotoProgressView> {
                           fontSize: 12,
                           fontWeight: FontWeight.w400,
                           onPressed: () {
-                            Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                builder: (context) =>
-                                    const ComparisonView(),
-                              ),
-                            );
+                            context.push(AppRoute.photoComparison);
                           },
                         ),
                       )

--- a/lib/view/photo_progress/result_view.dart
+++ b/lib/view/photo_progress/result_view.dart
@@ -2,6 +2,7 @@
 
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:simple_animation_progress_bar/simple_animation_progress_bar.dart';
 
 import '../../common/color_extension.dart';
@@ -60,7 +61,7 @@ class _ResultViewState extends State<ResultView> {
         centerTitle: true,
         elevation: 0,
         leading: InkWell(
-          onTap: () => Navigator.pop(context),
+          onTap: () => context.pop(),
           child: Container(
             margin: const EdgeInsets.all(8),
             alignment: Alignment.center,
@@ -282,7 +283,7 @@ class _ResultViewState extends State<ResultView> {
 
         // CTA
         const SizedBox(height: 16),
-        RoundButton(title: "Back to Home", onPressed: () => Navigator.pop(context)),
+        RoundButton(title: "Back to Home", onPressed: () => context.pop()),
         const SizedBox(height: 15),
       ],
     );
@@ -428,7 +429,7 @@ class _ResultViewState extends State<ResultView> {
 
         // CTA
         const SizedBox(height: 16),
-        RoundButton(title: "Back to Home", onPressed: () => Navigator.pop(context)),
+        RoundButton(title: "Back to Home", onPressed: () => context.pop()),
         const SizedBox(height: 15),
       ],
     );

--- a/lib/view/sleep_tracker/sleep_add_alarm_view.dart
+++ b/lib/view/sleep_tracker/sleep_add_alarm_view.dart
@@ -2,6 +2,7 @@
 
 import 'package:animated_toggle_switch/animated_toggle_switch.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../common/color_extension.dart';
 import '../../common_widget/icon_title_next_row.dart';
@@ -28,7 +29,7 @@ class _SleepAddAlarmViewState extends State<SleepAddAlarmView> {
         centerTitle: true,
         elevation: 0,
         leading: InkWell(
-          onTap: () => Navigator.pop(context),
+          onTap: () => context.pop(),
           child: Container(
             margin: const EdgeInsets.all(8),
             height: 40,

--- a/lib/view/sleep_tracker/sleep_schedule_view.dart
+++ b/lib/view/sleep_tracker/sleep_schedule_view.dart
@@ -1,8 +1,9 @@
 // lib/view/sleep_tracker/sleep_schedule_view.dart
 
+import 'package:aigymbuddy/common/app_router.dart';
 import 'package:calendar_agenda/calendar_agenda.dart';
-import 'package:aigymbuddy/view/sleep_tracker/sleep_add_alarm_view.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:simple_animation_progress_bar/simple_animation_progress_bar.dart';
 
 import '../../common/color_extension.dart';
@@ -53,7 +54,7 @@ class _SleepScheduleViewState extends State<SleepScheduleView> {
         centerTitle: true,
         elevation: 0,
         leading: InkWell(
-          onTap: () => Navigator.pop(context),
+          onTap: () => context.pop(),
           child: Container(
             margin: const EdgeInsets.all(8),
             height: 40,
@@ -281,14 +282,7 @@ class _SleepScheduleViewState extends State<SleepScheduleView> {
       ),
       floatingActionButton: InkWell(
         onTap: () {
-          Navigator.push(
-            context,
-            MaterialPageRoute(
-              builder: (context) => SleepAddAlarmView(
-                date: _selectedDateAppBBar,
-              ),
-            ),
-          );
+          context.push(AppRoute.sleepAddAlarm, extra: _selectedDateAppBBar);
         },
         child: Container(
           width: 55,

--- a/lib/view/sleep_tracker/sleep_tracker_view.dart
+++ b/lib/view/sleep_tracker/sleep_tracker_view.dart
@@ -1,8 +1,9 @@
 // lib/view/sleep_tracker/sleep_tracker_view.dart
 
-import 'package:aigymbuddy/view/sleep_tracker/sleep_schedule_view.dart';
+import 'package:aigymbuddy/common/app_router.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../common/color_extension.dart';
 import '../../common_widget/round_button.dart';
@@ -44,7 +45,7 @@ class _SleepTrackerViewState extends State<SleepTrackerView> {
         centerTitle: true,
         elevation: 0,
         leading: InkWell(
-          onTap: () => Navigator.pop(context),
+          onTap: () => context.pop(),
           child: Container(
             margin: const EdgeInsets.all(8),
             height: 40,
@@ -278,12 +279,7 @@ class _SleepTrackerViewState extends State<SleepTrackerView> {
                         fontSize: 12,
                         fontWeight: FontWeight.w400,
                         onPressed: () {
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                              builder: (context) => const SleepScheduleView(),
-                            ),
-                          );
+                          context.push(AppRoute.sleepSchedule);
                         },
                       ),
                     ),

--- a/lib/view/workout_tracker/add_schedule_view.dart
+++ b/lib/view/workout_tracker/add_schedule_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../common/color_extension.dart';
 import '../../common/common.dart';
@@ -26,7 +27,7 @@ class _AddScheduleViewState extends State<AddScheduleView> {
         elevation: 0,
         leading: InkWell(
           onTap: () {
-            Navigator.pop(context);
+            context.pop();
           },
           child: Container(
             margin: const EdgeInsets.all(8),

--- a/lib/view/workout_tracker/exercises_stpe_details.dart
+++ b/lib/view/workout_tracker/exercises_stpe_details.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:readmore/readmore.dart';
 
 import '../../common/color_extension.dart';
@@ -52,7 +53,7 @@ class _ExercisesStepDetailsState extends State<ExercisesStepDetails> {
         elevation: 0,
         leading: InkWell(
           onTap: () {
-            Navigator.pop(context);
+            context.pop();
           },
           child: Container(
             margin: const EdgeInsets.all(8),

--- a/lib/view/workout_tracker/workour_detail_view.dart
+++ b/lib/view/workout_tracker/workour_detail_view.dart
@@ -1,9 +1,9 @@
+import 'package:aigymbuddy/common/app_router.dart';
 import 'package:aigymbuddy/common/color_extension.dart';
 import 'package:aigymbuddy/common_widget/icon_title_next_row.dart';
 import 'package:aigymbuddy/common_widget/round_button.dart';
-import 'package:aigymbuddy/view/workout_tracker/exercises_stpe_details.dart';
-import 'package:aigymbuddy/view/workout_tracker/workout_schedule_view.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../common_widget/exercises_set_section.dart';
 
@@ -99,7 +99,7 @@ class _WorkoutDetailViewState extends State<WorkoutDetailView> {
               elevation: 0,
               leading: InkWell(
                 onTap: () {
-                  Navigator.pop(context);
+                  context.pop();
                 },
                 child: Container(
                   margin: const EdgeInsets.all(8),
@@ -225,8 +225,7 @@ class _WorkoutDetailViewState extends State<WorkoutDetailView> {
                           time: "5/27, 09:00 AM",
                           color: TColor.primaryColor2.withValues(alpha: 0.3),
                           onPressed: () {
-
-                              Navigator.push(context, MaterialPageRoute(builder: (context) => const WorkoutScheduleView() )  );
+                            context.push(AppRoute.workoutSchedule);
                           }),
                       SizedBox(
                         height: media.width * 0.02,
@@ -336,13 +335,9 @@ class _WorkoutDetailViewState extends State<WorkoutDetailView> {
                             return ExercisesSetSection(
                               sObj: sObj,
                               onPressed: (obj) {
-                                Navigator.push(
-                                  context,
-                                  MaterialPageRoute(
-                                    builder: (context) => ExercisesStepDetails(
-                                      eObj: obj,
-                                    ),
-                                  ),
+                                context.push(
+                                  AppRoute.exerciseSteps,
+                                  extra: Map<String, dynamic>.from(obj as Map),
                                 );
                               },
                             );

--- a/lib/view/workout_tracker/workout_schedule_view.dart
+++ b/lib/view/workout_tracker/workout_schedule_view.dart
@@ -1,12 +1,13 @@
 // lib/view/workout_tracker/workout_schedule_view.dart
 
+import 'package:aigymbuddy/common/app_router.dart';
 import 'package:calendar_agenda/calendar_agenda.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../common/color_extension.dart';
 import '../../common/common.dart';
 import '../../common_widget/round_button.dart';
-import 'add_schedule_view.dart';
 
 class WorkoutScheduleView extends StatefulWidget {
   const WorkoutScheduleView({super.key});
@@ -70,7 +71,7 @@ class _WorkoutScheduleViewState extends State<WorkoutScheduleView> {
         centerTitle: true,
         elevation: 0,
         leading: InkWell(
-          onTap: () => Navigator.pop(context),
+          onTap: () => context.pop(),
           child: Container(
             margin: const EdgeInsets.all(8),
             height: 40,
@@ -233,8 +234,7 @@ class _WorkoutScheduleViewState extends State<WorkoutScheduleView> {
                                                       children: [
                                                         InkWell(
                                                           onTap: () =>
-                                                              Navigator.pop(
-                                                                  context),
+                                                              context.pop(),
                                                           child: Container(
                                                             margin:
                                                                 const EdgeInsets
@@ -380,12 +380,7 @@ class _WorkoutScheduleViewState extends State<WorkoutScheduleView> {
       ),
       floatingActionButton: InkWell(
         onTap: () {
-          Navigator.push(
-            context,
-            MaterialPageRoute(
-              builder: (context) => AddScheduleView(date: _selectedDateAppBBar),
-            ),
-          );
+          context.push(AppRoute.addWorkoutSchedule, extra: _selectedDateAppBBar);
         },
         child: Container(
           width: 55,

--- a/lib/view/workout_tracker/workout_tracker_view.dart
+++ b/lib/view/workout_tracker/workout_tracker_view.dart
@@ -1,9 +1,10 @@
 // lib/view/workout_tracker/workout_tracker_view.dart
 
+import 'package:aigymbuddy/common/app_router.dart';
 import 'package:aigymbuddy/common/color_extension.dart';
-import 'package:aigymbuddy/view/workout_tracker/workour_detail_view.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../common_widget/round_button.dart';
 import '../../common_widget/upcoming_workout_row.dart';
@@ -67,7 +68,7 @@ class _WorkoutTrackerViewState extends State<WorkoutTrackerView> {
               centerTitle: true,
               elevation: 0,
               leading: InkWell(
-                onTap: () => Navigator.pop(context),
+                onTap: () => context.pop(),
                 child: Container(
                   margin: const EdgeInsets.all(8),
                   height: 40,
@@ -322,11 +323,9 @@ class _WorkoutTrackerViewState extends State<WorkoutTrackerView> {
                       return InkWell(
                         onTap: () {
                           // Pastikan parameter bertipe Map<String, dynamic>
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                              builder: (context) => WorkoutDetailView(dObj: Map<String, dynamic>.from(wObj)),
-                            ),
+                          context.push(
+                            AppRoute.workoutDetail,
+                            extra: Map<String, dynamic>.from(wObj),
                           );
                         },
                         child: WhatTrainRow(wObj: Map<String, dynamic>.from(wObj)),


### PR DESCRIPTION
## Summary
- introduce a centralized `AppRouter` with all application routes configured for go_router
- update the app entry point to use `MaterialApp.router` and replace legacy Navigator.push/pop calls across the views with go_router navigation helpers
- pass strongly typed data through go_router extras for views that require parameters, while normalizing all back navigation to `context.pop()`

## Testing
- not run (flutter tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6657bd5308333a5a41f5ee4a9b50a