### PR TITLE
Improve GoRouter configuration and theme cleanup

### DIFF
--- a/lib/common/app_router.dart
+++ b/lib/common/app_router.dart
@@ -1,32 +1,31 @@
+import 'package:aigymbuddy/view/home/activity_tracker_view.dart';
+import 'package:aigymbuddy/view/home/finished_workout_view.dart';
+import 'package:aigymbuddy/view/home/notification_view.dart';
+import 'package:aigymbuddy/view/login/complete_profile_view.dart';
+import 'package:aigymbuddy/view/login/login_view.dart';
+import 'package:aigymbuddy/view/login/signup_view.dart';
+import 'package:aigymbuddy/view/login/welcome_view.dart';
+import 'package:aigymbuddy/view/login/what_your_goal_view.dart';
+import 'package:aigymbuddy/view/main_tab/main_tab_view.dart';
+import 'package:aigymbuddy/view/main_tab/select_view.dart';
+import 'package:aigymbuddy/view/meal_planner/food_info_details_view.dart';
+import 'package:aigymbuddy/view/meal_planner/meal_food_details_view.dart';
+import 'package:aigymbuddy/view/meal_planner/meal_planner_view.dart';
+import 'package:aigymbuddy/view/meal_planner/meal_schedule_view.dart';
+import 'package:aigymbuddy/view/on_boarding/on_boarding_view.dart';
+import 'package:aigymbuddy/view/photo_progress/comparison_view.dart';
+import 'package:aigymbuddy/view/photo_progress/photo_progress_view.dart';
+import 'package:aigymbuddy/view/photo_progress/result_view.dart';
+import 'package:aigymbuddy/view/profile/profile_view.dart';
+import 'package:aigymbuddy/view/sleep_tracker/sleep_add_alarm_view.dart';
+import 'package:aigymbuddy/view/sleep_tracker/sleep_schedule_view.dart';
+import 'package:aigymbuddy/view/sleep_tracker/sleep_tracker_view.dart';
+import 'package:aigymbuddy/view/workout_tracker/add_schedule_view.dart';
+import 'package:aigymbuddy/view/workout_tracker/exercises_stpe_details.dart';
+import 'package:aigymbuddy/view/workout_tracker/workout_schedule_view.dart';
+import 'package:aigymbuddy/view/workout_tracker/workout_tracker_view.dart';
+import 'package:aigymbuddy/view/workout_tracker/workour_detail_view.dart';
 import 'package:go_router/go_router.dart';
-
-import '../view/home/activity_tracker_view.dart';
-import '../view/home/finished_workout_view.dart';
-import '../view/home/notification_view.dart';
-import '../view/login/complete_profile_view.dart';
-import '../view/login/login_view.dart';
-import '../view/login/signup_view.dart';
-import '../view/login/welcome_view.dart';
-import '../view/login/what_your_goal_view.dart';
-import '../view/main_tab/main_tab_view.dart';
-import '../view/main_tab/select_view.dart';
-import '../view/meal_planner/food_info_details_view.dart';
-import '../view/meal_planner/meal_food_details_view.dart';
-import '../view/meal_planner/meal_planner_view.dart';
-import '../view/meal_planner/meal_schedule_view.dart';
-import '../view/on_boarding/on_boarding_view.dart';
-import '../view/photo_progress/comparison_view.dart';
-import '../view/photo_progress/photo_progress_view.dart';
-import '../view/photo_progress/result_view.dart';
-import '../view/profile/profile_view.dart';
-import '../view/sleep_tracker/sleep_add_alarm_view.dart';
-import '../view/sleep_tracker/sleep_schedule_view.dart';
-import '../view/sleep_tracker/sleep_tracker_view.dart';
-import '../view/workout_tracker/add_schedule_view.dart';
-import '../view/workout_tracker/exercises_stpe_details.dart';
-import '../view/workout_tracker/workout_schedule_view.dart';
-import '../view/workout_tracker/workout_tracker_view.dart';
-import '../view/workout_tracker/workour_detail_view.dart';
 
 class AppRoute {
   static const String main = '/';
@@ -54,6 +53,8 @@ class AppRoute {
   static const String sleepTracker = '/sleep-tracker';
   static const String sleepSchedule = '/sleep-tracker/schedule';
   static const String sleepAddAlarm = '/sleep-tracker/add-alarm';
+  static const String profile = '/profile';
+  static const String select = '/select';
 }
 
 class AppRouter {
@@ -111,31 +112,35 @@ class AppRouter {
       GoRoute(
         path: AppRoute.addWorkoutSchedule,
         builder: (context, state) {
-          final extra = state.extra;
-          if (extra is! DateTime) {
-            throw ArgumentError('AddScheduleView requires a DateTime extra.');
-          }
-          return AddScheduleView(date: extra);
+          final date = _requireExtra<DateTime>(
+            state,
+            'AddScheduleView requires a DateTime extra.',
+          );
+          return AddScheduleView(date: date);
         },
       ),
       GoRoute(
         path: AppRoute.workoutDetail,
         builder: (context, state) {
-          final extra = state.extra;
-          if (extra is! Map) {
-            throw ArgumentError('WorkoutDetailView requires a Map extra.');
-          }
-          return WorkoutDetailView(dObj: Map<String, dynamic>.from(extra));
+          final data = Map<String, dynamic>.from(
+            _requireExtra<Map>(
+              state,
+              'WorkoutDetailView requires a Map extra.',
+            ),
+          );
+          return WorkoutDetailView(dObj: data);
         },
       ),
       GoRoute(
         path: AppRoute.exerciseSteps,
         builder: (context, state) {
-          final extra = state.extra;
-          if (extra is! Map) {
-            throw ArgumentError('ExercisesStepDetails requires a Map extra.');
-          }
-          return ExercisesStepDetails(eObj: Map<String, dynamic>.from(extra));
+          final data = Map<String, dynamic>.from(
+            _requireExtra<Map>(
+              state,
+              'ExercisesStepDetails requires a Map extra.',
+            ),
+          );
+          return ExercisesStepDetails(eObj: data);
         },
       ),
       GoRoute(
@@ -149,21 +154,24 @@ class AppRouter {
       GoRoute(
         path: AppRoute.mealFoodDetails,
         builder: (context, state) {
-          final extra = state.extra;
-          if (extra is! Map) {
-            throw ArgumentError('MealFoodDetailsView requires a Map extra.');
-          }
-          return MealFoodDetailsView(eObj: Map<String, dynamic>.from(extra));
+          final data = Map<String, dynamic>.from(
+            _requireExtra<Map>(
+              state,
+              'MealFoodDetailsView requires a Map extra.',
+            ),
+          );
+          return MealFoodDetailsView(eObj: data);
         },
       ),
       GoRoute(
         path: AppRoute.foodInfo,
         builder: (context, state) {
-          final extra = state.extra;
-          if (extra is! Map) {
-            throw ArgumentError('FoodInfoDetailsView requires a Map extra.');
-          }
-          final map = Map<String, dynamic>.from(extra);
+          final map = Map<String, dynamic>.from(
+            _requireExtra<Map>(
+              state,
+              'FoodInfoDetailsView requires a Map extra.',
+            ),
+          );
           final meal = map['meal'];
           final food = map['food'];
           if (meal is! Map || food is! Map) {
@@ -186,11 +194,12 @@ class AppRouter {
       GoRoute(
         path: AppRoute.photoResult,
         builder: (context, state) {
-          final extra = state.extra;
-          if (extra is! Map) {
-            throw ArgumentError('ResultView requires a Map extra.');
-          }
-          final map = Map<String, dynamic>.from(extra);
+          final map = Map<String, dynamic>.from(
+            _requireExtra<Map>(
+              state,
+              'ResultView requires a Map extra.',
+            ),
+          );
           final date1 = map['date1'];
           final date2 = map['date2'];
           if (date1 is! DateTime || date2 is! DateTime) {
@@ -210,21 +219,29 @@ class AppRouter {
       GoRoute(
         path: AppRoute.sleepAddAlarm,
         builder: (context, state) {
-          final extra = state.extra;
-          if (extra is! DateTime) {
-            throw ArgumentError('SleepAddAlarmView requires a DateTime extra.');
-          }
-          return SleepAddAlarmView(date: extra);
+          final date = _requireExtra<DateTime>(
+            state,
+            'SleepAddAlarmView requires a DateTime extra.',
+          );
+          return SleepAddAlarmView(date: date);
         },
       ),
       GoRoute(
-        path: '/profile',
+        path: AppRoute.profile,
         builder: (context, state) => const ProfileView(),
       ),
       GoRoute(
-        path: '/select',
+        path: AppRoute.select,
         builder: (context, state) => const SelectView(),
       ),
     ],
   );
+}
+
+T _requireExtra<T extends Object>(GoRouterState state, String message) {
+  final extra = state.extra;
+  if (extra is! T) {
+    throw ArgumentError(message);
+  }
+  return extra;
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,30 +9,14 @@ void main() {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp.router(
       title: 'AI Gym Buddy',
       debugShowCheckedModeBanner: false,
       theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
         primaryColor: TColor.primaryColor1,
-        fontFamily: "Poppins"
+        fontFamily: 'Poppins',
       ),
       routerConfig: AppRouter.router,
     );


### PR DESCRIPTION
## Summary
- switch router imports to package paths and add route constants for profile/select screens
- centralize GoRouter extra validation via a helper to improve error messaging
- remove boilerplate comments and simplify the MaterialApp theme configuration

## Testing
- Not run (Dart SDK unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d66fff0f408333a38760a635d02a10