### PR TITLE
Add onboarding gate based on saved credentials

### DIFF
--- a/lib/common/app_router.dart
+++ b/lib/common/app_router.dart
@@ -12,6 +12,7 @@ import 'package:aigymbuddy/view/meal_planner/food_info_details_view.dart';
 import 'package:aigymbuddy/view/meal_planner/meal_food_details_view.dart';
 import 'package:aigymbuddy/view/meal_planner/meal_planner_view.dart';
 import 'package:aigymbuddy/view/meal_planner/meal_schedule_view.dart';
+import 'package:aigymbuddy/view/splash/launch_view.dart';
 import 'package:aigymbuddy/view/on_boarding/on_boarding_view.dart';
 import 'package:aigymbuddy/view/photo_progress/comparison_view.dart';
 import 'package:aigymbuddy/view/photo_progress/photo_progress_view.dart';
@@ -28,7 +29,8 @@ import 'package:aigymbuddy/view/workout_tracker/workour_detail_view.dart';
 import 'package:go_router/go_router.dart';
 
 class AppRoute {
-  static const String main = '/';
+  static const String launch = '/';
+  static const String main = '/home';
   static const String onboarding = '/onboarding';
   static const String login = '/login';
   static const String signUp = '/sign-up';
@@ -59,8 +61,12 @@ class AppRoute {
 
 class AppRouter {
   static final GoRouter router = GoRouter(
-    initialLocation: AppRoute.main,
+    initialLocation: AppRoute.launch,
     routes: [
+      GoRoute(
+        path: AppRoute.launch,
+        builder: (context, state) => const LaunchView(),
+      ),
       GoRoute(
         path: AppRoute.main,
         builder: (context, state) => const MainTabView(),

--- a/lib/common/services/auth_service.dart
+++ b/lib/common/services/auth_service.dart
@@ -1,0 +1,19 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class AuthService {
+  AuthService._();
+
+  static final AuthService instance = AuthService._();
+
+  static const String _hasCredentialsKey = 'auth.hasCredentials';
+
+  Future<bool> hasSavedCredentials() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_hasCredentialsKey) ?? false;
+  }
+
+  Future<void> setHasCredentials(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_hasCredentialsKey, value);
+  }
+}

--- a/lib/view/login/welcome_view.dart
+++ b/lib/view/login/welcome_view.dart
@@ -1,9 +1,9 @@
 // lib/view/login/welcome_view.dart
 
 import 'package:aigymbuddy/common/app_router.dart';
+import 'package:aigymbuddy/common/services/auth_service.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-
 import '../../common/color_extension.dart';
 import '../../common_widget/round_button.dart';
 
@@ -56,7 +56,9 @@ SizedBox(
 
                 RoundButton(
                   title: "Go To Home",
-                  onPressed: () {
+                  onPressed: () async {
+                    await AuthService.instance.setHasCredentials(true);
+                    if (!mounted) return;
                     context.go(AppRoute.main);
                 }),
               

--- a/lib/view/splash/launch_view.dart
+++ b/lib/view/splash/launch_view.dart
@@ -1,0 +1,39 @@
+import 'package:aigymbuddy/common/app_router.dart';
+import 'package:aigymbuddy/common/services/auth_service.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class LaunchView extends StatefulWidget {
+  const LaunchView({super.key});
+
+  @override
+  State<LaunchView> createState() => _LaunchViewState();
+}
+
+class _LaunchViewState extends State<LaunchView> {
+  @override
+  void initState() {
+    super.initState();
+    _bootstrap();
+  }
+
+  Future<void> _bootstrap() async {
+    final hasCredentials = await AuthService.instance.hasSavedCredentials();
+    if (!mounted) return;
+
+    if (hasCredentials) {
+      context.go(AppRoute.main);
+    } else {
+      context.go(AppRoute.onboarding);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: CircularProgressIndicator(),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
     path: dev_lib/calendar_agenda/
   intl: ^0.20.2
   go_router: ^16.2.4
+  shared_preferences: ^2.3.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add a lightweight AuthService that stores whether credentials exist in shared preferences
- introduce a launch gate that routes first-time users to onboarding and returning users to the main tab
- persist credential state when finishing onboarding and add the shared_preferences dependency

## Testing
- not run (Flutter/Dart tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7a2e0dbcc83339933fb1830def739