### PR TITLE
Revamp welcome onboarding screen styling

### DIFF
--- a/lib/common_widget/on_boarding_page.dart
+++ b/lib/common_widget/on_boarding_page.dart
@@ -12,6 +12,7 @@ class OnBoardingContent {
     this.titleColor,
     this.subtitleColor,
     this.textAlign,
+    this.buttonText,
     this.isWelcome = false,
   });
 
@@ -23,13 +24,15 @@ class OnBoardingContent {
   final Color? titleColor;
   final Color? subtitleColor;
   final TextAlign? textAlign;
+  final String? buttonText;
   final bool isWelcome;
 }
 
 class OnBoardingPage extends StatelessWidget {
-  const OnBoardingPage({super.key, required this.content});
+  const OnBoardingPage({super.key, required this.content, this.onNext});
 
   final OnBoardingContent content;
+  final VoidCallback? onNext;
 
   @override
   Widget build(BuildContext context) {
@@ -41,41 +44,69 @@ class OnBoardingPage extends StatelessWidget {
         height: media.height,
         color: content.backgroundColor ?? TColor.white,
         child: SafeArea(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              const Spacer(),
-              Text(
-                content.title,
-                textAlign: content.textAlign ?? TextAlign.center,
-                style: TextStyle(
-                  color: content.titleColor ?? TColor.primaryColor1,
-                  fontSize: 32,
-                  fontWeight: FontWeight.w800,
-                  letterSpacing: 1.2,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(32, 48, 32, 40),
+            child: Column(
+              children: [
+                const Spacer(),
+                Text(
+                  content.title,
+                  textAlign: content.textAlign ?? TextAlign.center,
+                  style: TextStyle(
+                    color: content.titleColor ?? TColor.black,
+                    fontSize: 34,
+                    fontWeight: FontWeight.w800,
+                    letterSpacing: 1.2,
+                  ),
                 ),
-              ),
-              const SizedBox(height: 12),
-              Text(
-                content.subtitle,
-                textAlign: content.textAlign ?? TextAlign.center,
-                style: TextStyle(
-                  color: content.subtitleColor ?? TColor.gray,
-                  fontSize: 16,
-                  fontWeight: FontWeight.w500,
+                const SizedBox(height: 12),
+                Text(
+                  content.subtitle,
+                  textAlign: content.textAlign ?? TextAlign.center,
+                  style: TextStyle(
+                    color: content.subtitleColor ?? TColor.gray,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w500,
+                  ),
                 ),
-              ),
-              const Spacer(),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 32),
-                child: Image.asset(
-                  content.image,
-                  width: media.width,
-                  fit: BoxFit.contain,
-                ),
-              ),
-              const SizedBox(height: 48),
-            ],
+                const Spacer(),
+                if (content.buttonText != null)
+                  SizedBox(
+                    width: double.infinity,
+                    child: GestureDetector(
+                      onTap: onNext,
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(vertical: 18),
+                        decoration: BoxDecoration(
+                          gradient: LinearGradient(
+                            colors: content.gradientColors ?? TColor.primaryG,
+                            begin: Alignment.centerLeft,
+                            end: Alignment.centerRight,
+                          ),
+                          borderRadius: BorderRadius.circular(30),
+                          boxShadow: [
+                            BoxShadow(
+                              color: TColor.primaryColor1.withValues(alpha: 0.2),
+                              blurRadius: 16,
+                              offset: const Offset(0, 8),
+                            ),
+                          ],
+                        ),
+                        child: Text(
+                          content.buttonText!,
+                          textAlign: TextAlign.center,
+                          style: TextStyle(
+                            color: TColor.white,
+                            fontSize: 16,
+                            fontWeight: FontWeight.w600,
+                            letterSpacing: 0.4,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+              ],
+            ),
           ),
         ),
       );

--- a/lib/view/on_boarding/on_boarding_view.dart
+++ b/lib/view/on_boarding/on_boarding_view.dart
@@ -24,6 +24,7 @@ class _OnBoardingViewState extends State<OnBoardingView> {
       titleColor: TColor.primaryColor1,
       subtitleColor: TColor.gray,
       textAlign: TextAlign.center,
+      buttonText: 'Get Started',
       isWelcome: true,
     ),
     OnBoardingContent(
@@ -85,6 +86,8 @@ class _OnBoardingViewState extends State<OnBoardingView> {
     final totalPages = pageArr.length;
     final progress = (selectPage + 1) / totalPages;
 
+    final isWelcome = pageArr[selectPage].isWelcome;
+
     return Scaffold(
       backgroundColor: TColor.white,
       body: Stack(
@@ -99,56 +102,60 @@ class _OnBoardingViewState extends State<OnBoardingView> {
               });
             },
             itemBuilder: (context, index) {
-              return OnBoardingPage(content: pageArr[index]);
+              return OnBoardingPage(
+                content: pageArr[index],
+                onNext: _handleNext,
+              );
             },
           ),
-          Padding(
-            padding: const EdgeInsets.only(right: 24, bottom: 40),
-            child: SizedBox(
-              width: 120,
-              height: 120,
-              child: Stack(
-                alignment: Alignment.center,
-                children: [
-                  SizedBox(
-                    width: 80,
-                    height: 80,
-                    child: CircularProgressIndicator(
-                      color: TColor.primaryColor1,
-                      value: progress,
-                      strokeWidth: 3,
-                      backgroundColor: TColor.lightGray,
-                    ),
-                  ),
-                  Container(
-                    width: 70,
-                    height: 70,
-                    decoration: BoxDecoration(
-                      color: TColor.primaryColor1,
-                      borderRadius: BorderRadius.circular(40),
-                      boxShadow: [
-                        BoxShadow(
-                          color: TColor.primaryColor1.withValues(alpha: 0.3),
-                          blurRadius: 12,
-                          offset: const Offset(0, 6),
-                        ),
-                      ],
-                    ),
-                    child: IconButton(
-                      onPressed: _handleNext,
-                      icon: Icon(
-                        selectPage == totalPages - 1
-                            ? Icons.check_rounded
-                            : Icons.arrow_forward_rounded,
-                        color: TColor.white,
-                        size: 28,
+          if (!isWelcome)
+            Padding(
+              padding: const EdgeInsets.only(right: 24, bottom: 40),
+              child: SizedBox(
+                width: 120,
+                height: 120,
+                child: Stack(
+                  alignment: Alignment.center,
+                  children: [
+                    SizedBox(
+                      width: 80,
+                      height: 80,
+                      child: CircularProgressIndicator(
+                        color: TColor.primaryColor1,
+                        value: progress,
+                        strokeWidth: 3,
+                        backgroundColor: TColor.lightGray,
                       ),
                     ),
-                  ),
-                ],
+                    Container(
+                      width: 70,
+                      height: 70,
+                      decoration: BoxDecoration(
+                        color: TColor.primaryColor1,
+                        borderRadius: BorderRadius.circular(40),
+                        boxShadow: [
+                          BoxShadow(
+                            color: TColor.primaryColor1.withValues(alpha: 0.3),
+                            blurRadius: 12,
+                            offset: const Offset(0, 6),
+                          ),
+                        ],
+                      ),
+                      child: IconButton(
+                        onPressed: _handleNext,
+                        icon: Icon(
+                          selectPage == totalPages - 1
+                              ? Icons.check_rounded
+                              : Icons.arrow_forward_rounded,
+                          color: TColor.white,
+                          size: 28,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
-          ),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- redesign the welcome onboarding screen with a minimal layout, centered copy, and a gradient start button
- allow onboarding pages to render an inline action and hide the floating progress control on the welcome step

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7cab3a7448333b4d6bf1d91a33504