### PR TITLE
Refine onboarding layout

### DIFF
--- a/lib/common_widget/on_boarding_page.dart
+++ b/lib/common_widget/on_boarding_page.dart
@@ -115,22 +115,17 @@ class OnBoardingPage extends StatelessWidget {
     return Container(
       width: media.width,
       height: media.height,
-      decoration: BoxDecoration(
-        gradient: LinearGradient(
-          colors: content.gradientColors ?? TColor.primaryG,
-          begin: Alignment.topCenter,
-          end: Alignment.bottomCenter,
-        ),
-      ),
+      color: TColor.white,
       child: SafeArea(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Expanded(
-              child: Align(
-                alignment: Alignment.topCenter,
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 28),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              const SizedBox(height: 12),
+              Expanded(
+                child: Align(
+                  alignment: Alignment.topCenter,
                   child: Image.asset(
                     content.image,
                     fit: BoxFit.contain,
@@ -138,43 +133,29 @@ class OnBoardingPage extends StatelessWidget {
                   ),
                 ),
               ),
-            ),
-            Container(
-              decoration: BoxDecoration(
-                color: TColor.white,
-                borderRadius: const BorderRadius.only(
-                  topLeft: Radius.circular(32),
-                  topRight: Radius.circular(32),
+              const SizedBox(height: 24),
+              Text(
+                content.title,
+                textAlign: content.textAlign ?? TextAlign.center,
+                style: TextStyle(
+                  color: content.titleColor ?? TColor.black,
+                  fontSize: 28,
+                  fontWeight: FontWeight.w700,
                 ),
               ),
-              padding: const EdgeInsets.fromLTRB(24, 32, 24, 48),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    content.title,
-                    textAlign: content.textAlign ?? TextAlign.left,
-                    style: TextStyle(
-                      color: content.titleColor ?? TColor.black,
-                      fontSize: 26,
-                      fontWeight: FontWeight.w700,
-                    ),
-                  ),
-                  const SizedBox(height: 16),
-                  Text(
-                    content.subtitle,
-                    textAlign: content.textAlign ?? TextAlign.left,
-                    style: TextStyle(
-                      color: content.subtitleColor ?? TColor.gray,
-                      fontSize: 15,
-                      height: 1.5,
-                    ),
-                  ),
-                ],
+              const SizedBox(height: 12),
+              Text(
+                content.subtitle,
+                textAlign: content.textAlign ?? TextAlign.center,
+                style: TextStyle(
+                  color: content.subtitleColor ?? TColor.gray,
+                  fontSize: 15,
+                  height: 1.5,
+                ),
               ),
-            ),
-          ],
+              const SizedBox(height: 80),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/view/on_boarding/on_boarding_view.dart
+++ b/lib/view/on_boarding/on_boarding_view.dart
@@ -112,14 +112,14 @@ class _OnBoardingViewState extends State<OnBoardingView> {
             Padding(
               padding: const EdgeInsets.only(right: 24, bottom: 40),
               child: SizedBox(
-                width: 120,
-                height: 120,
+                width: 88,
+                height: 88,
                 child: Stack(
                   alignment: Alignment.center,
                   children: [
                     SizedBox(
-                      width: 80,
-                      height: 80,
+                      width: 72,
+                      height: 72,
                       child: CircularProgressIndicator(
                         color: TColor.primaryColor1,
                         value: progress,
@@ -127,28 +127,35 @@ class _OnBoardingViewState extends State<OnBoardingView> {
                         backgroundColor: TColor.lightGray,
                       ),
                     ),
-                    Container(
-                      width: 70,
-                      height: 70,
+                    DecoratedBox(
                       decoration: BoxDecoration(
-                        color: TColor.primaryColor1,
-                        borderRadius: BorderRadius.circular(40),
+                        gradient: LinearGradient(
+                          colors: pageArr[selectPage].gradientColors ?? TColor.primaryG,
+                          begin: Alignment.topLeft,
+                          end: Alignment.bottomRight,
+                        ),
+                        shape: BoxShape.circle,
                         boxShadow: [
                           BoxShadow(
-                            color: TColor.primaryColor1.withValues(alpha: 0.3),
-                            blurRadius: 12,
+                            color: (pageArr[selectPage].gradientColors ?? TColor.primaryG)
+                                .last
+                                .withValues(alpha: 0.3),
+                            blurRadius: 10,
                             offset: const Offset(0, 6),
                           ),
                         ],
                       ),
-                      child: IconButton(
-                        onPressed: _handleNext,
-                        icon: Icon(
-                          selectPage == totalPages - 1
-                              ? Icons.check_rounded
-                              : Icons.arrow_forward_rounded,
-                          color: TColor.white,
-                          size: 28,
+                      child: SizedBox(
+                        width: 56,
+                        height: 56,
+                        child: IconButton(
+                          onPressed: _handleNext,
+                          icon: Icon(
+                            selectPage == totalPages - 1
+                                ? Icons.check_rounded
+                                : Icons.arrow_forward_rounded,
+                            color: TColor.white,
+                          ),
                         ),
                       ),
                     ),


### PR DESCRIPTION
## Summary
- simplify the onboarding page layout to use a clean white background with centered imagery and copy
- adjust onboarding text styling and spacing for improved readability
- restyle the progress button with a compact gradient treatment that matches the artwork

## Testing
- not run (Flutter SDK not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7d1865b288333aaae063085266240