### PR TITLE
Revert onboarding UI to original simple design

### DIFF
--- a/lib/common_widget/on_boarding_page.dart
+++ b/lib/common_widget/on_boarding_page.dart
@@ -2,180 +2,50 @@ import 'package:flutter/material.dart';
 
 import '../common/color_extension.dart';
 
-class OnBoardingContent {
-  const OnBoardingContent({
-    required this.title,
-    required this.subtitle,
-    required this.image,
-    this.gradientColors,
-    this.backgroundColor,
-    this.titleColor,
-    this.subtitleColor,
-    this.textAlign,
-    this.buttonText,
-    this.isWelcome = false,
-  });
-
-  final String title;
-  final String subtitle;
-  final String image;
-  final List<Color>? gradientColors;
-  final Color? backgroundColor;
-  final Color? titleColor;
-  final Color? subtitleColor;
-  final TextAlign? textAlign;
-  final String? buttonText;
-  final bool isWelcome;
-}
-
 class OnBoardingPage extends StatelessWidget {
-  const OnBoardingPage({super.key, required this.content, this.onNext});
+  const OnBoardingPage({super.key, required this.pObj});
 
-  final OnBoardingContent content;
-  final VoidCallback? onNext;
+  final Map<String, String> pObj;
 
   @override
   Widget build(BuildContext context) {
     final media = MediaQuery.of(context).size;
 
-    if (content.isWelcome) {
-      return Container(
-        width: media.width,
-        height: media.height,
-        color: content.backgroundColor ?? TColor.white,
-        child: SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.fromLTRB(32, 48, 32, 40),
-            child: Column(
-              children: [
-                const Spacer(),
-                Text(
-                  content.title,
-                  textAlign: content.textAlign ?? TextAlign.center,
-                  style: TextStyle(
-                    color: content.titleColor ?? TColor.black,
-                    fontSize: 34,
-                    fontWeight: FontWeight.w800,
-                    letterSpacing: 1.2,
-                  ),
-                ),
-                const SizedBox(height: 12),
-                Text(
-                  content.subtitle,
-                  textAlign: content.textAlign ?? TextAlign.center,
-                  style: TextStyle(
-                    color: content.subtitleColor ?? TColor.gray,
-                    fontSize: 16,
-                    fontWeight: FontWeight.w500,
-                  ),
-                ),
-                const Spacer(),
-                if (content.buttonText != null)
-                  SizedBox(
-                    width: double.infinity,
-                    child: GestureDetector(
-                      onTap: onNext,
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(vertical: 18),
-                        decoration: BoxDecoration(
-                          gradient: LinearGradient(
-                            colors: content.gradientColors ?? TColor.primaryG,
-                            begin: Alignment.centerLeft,
-                            end: Alignment.centerRight,
-                          ),
-                          borderRadius: BorderRadius.circular(30),
-                          boxShadow: [
-                            BoxShadow(
-                              color: TColor.primaryColor1.withValues(alpha: 0.2),
-                              blurRadius: 16,
-                              offset: const Offset(0, 8),
-                            ),
-                          ],
-                        ),
-                        child: Text(
-                          content.buttonText!,
-                          textAlign: TextAlign.center,
-                          style: TextStyle(
-                            color: TColor.white,
-                            fontSize: 16,
-                            fontWeight: FontWeight.w600,
-                            letterSpacing: 0.4,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
-              ],
-            ),
-          ),
-        ),
-      );
-    }
-
-    return Container(
+    return SizedBox(
       width: media.width,
       height: media.height,
-      decoration: BoxDecoration(
-        gradient: LinearGradient(
-          colors: content.gradientColors ?? TColor.primaryG,
-          begin: Alignment.topCenter,
-          end: Alignment.bottomCenter,
-        ),
-      ),
-      child: SafeArea(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Expanded(
-              child: Align(
-                alignment: Alignment.topCenter,
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
-                  child: Image.asset(
-                    content.image,
-                    fit: BoxFit.contain,
-                    width: media.width * 0.8,
-                  ),
-                ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Image.asset(
+            pObj['image'].toString(),
+            width: media.width,
+            fit: BoxFit.fitWidth,
+          ),
+          SizedBox(height: media.width * 0.1),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 15),
+            child: Text(
+              pObj['title'].toString(),
+              style: TextStyle(
+                color: TColor.black,
+                fontSize: 24,
+                fontWeight: FontWeight.w700,
               ),
             ),
-            Container(
-              decoration: BoxDecoration(
-                color: TColor.white,
-                borderRadius: const BorderRadius.only(
-                  topLeft: Radius.circular(32),
-                  topRight: Radius.circular(32),
-                ),
-              ),
-              padding: const EdgeInsets.fromLTRB(24, 32, 24, 48),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    content.title,
-                    textAlign: content.textAlign ?? TextAlign.left,
-                    style: TextStyle(
-                      color: content.titleColor ?? TColor.black,
-                      fontSize: 26,
-                      fontWeight: FontWeight.w700,
-                    ),
-                  ),
-                  const SizedBox(height: 16),
-                  Text(
-                    content.subtitle,
-                    textAlign: content.textAlign ?? TextAlign.left,
-                    style: TextStyle(
-                      color: content.subtitleColor ?? TColor.gray,
-                      fontSize: 15,
-                      height: 1.5,
-                    ),
-                  ),
-                ],
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 15),
+            child: Text(
+              pObj['subtitle'].toString(),
+              style: TextStyle(
+                color: TColor.gray,
+                fontSize: 14,
               ),
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/view/on_boarding/on_boarding_view.dart
+++ b/lib/view/on_boarding/on_boarding_view.dart
@@ -1,8 +1,8 @@
-import 'package:aigymbuddy/common/app_router.dart';
-import 'package:aigymbuddy/common/color_extension.dart';
-import 'package:aigymbuddy/common_widget/on_boarding_page.dart';
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
+
+import '../../common/color_extension.dart';
+import '../../common_widget/on_boarding_page.dart';
+import '../login/signup_view.dart';
 
 class OnBoardingView extends StatefulWidget {
   const OnBoardingView({super.key});
@@ -12,57 +12,49 @@ class OnBoardingView extends StatefulWidget {
 }
 
 class _OnBoardingViewState extends State<OnBoardingView> {
-  final PageController controller = PageController();
+  late final PageController controller = PageController();
   int selectPage = 0;
 
-  late final List<OnBoardingContent> pageArr = [
-    OnBoardingContent(
-      title: 'AI GYM BUDDY',
-      subtitle: 'Everybody Can Train',
-      image: 'assets/img/welcome.png',
-      backgroundColor: TColor.white,
-      titleColor: TColor.black,
-      subtitleColor: TColor.gray,
-      textAlign: TextAlign.center,
-      buttonText: 'Get Started',
-      isWelcome: true,
-    ),
-    OnBoardingContent(
-      title: 'Track Your Goal',
-      subtitle:
+  final List<Map<String, String>> pageArr = [
+    {
+      'title': 'Track Your Goal',
+      'subtitle':
           "Don't worry if you have trouble determining your goals, We can help you determine your goals and track your goals",
-      image: 'assets/img/on_1.png',
-      gradientColors: TColor.primaryG,
-    ),
-    OnBoardingContent(
-      title: 'Get Burn',
-      subtitle:
+      'image': 'assets/img/on_1.png',
+    },
+    {
+      'title': 'Get Burn',
+      'subtitle':
           "Let’s keep burning, to achive yours goals, it hurts only temporarily, if you give up now you will be in pain forever",
-      image: 'assets/img/on_2.png',
-      gradientColors: TColor.secondaryG,
-    ),
-    OnBoardingContent(
-      title: 'Eat Well',
-      subtitle:
+      'image': 'assets/img/on_2.png',
+    },
+    {
+      'title': 'Eat Well',
+      'subtitle':
           "Let's start a healthy lifestyle with us, we can determine your diet every day. healthy eating is fun",
-      image: 'assets/img/on_3.png',
-      gradientColors: const [Color(0xff9DCEFF), Color(0xff92A3FD)],
-    ),
-    OnBoardingContent(
-      title: 'Improve Sleep\nQuality',
-      subtitle:
+      'image': 'assets/img/on_3.png',
+    },
+    {
+      'title': 'Improve Sleep\nQuality',
+      'subtitle':
           'Improve the quality of your sleep with us, good quality sleep can bring a good mood in the morning',
-      image: 'assets/img/on_4.png',
-      gradientColors: const [Color(0xff92A3FD), Color(0xff9DCEFF)],
-    ),
-    OnBoardingContent(
-      title: 'Smart AI Coach',
-      subtitle:
-          'Personalized programs backed with custom AI recommendations help you stay consistent on your fitness journey.',
-      image: 'assets/img/on_5.png',
-      gradientColors: const [Color(0xffC58BF2), Color(0xffEEA4CE)],
-    ),
+      'image': 'assets/img/on_4.png',
+    },
   ];
+
+  @override
+  void initState() {
+    super.initState();
+
+    controller.addListener(() {
+      final currentPage = controller.page?.round() ?? 0;
+      if (currentPage != selectPage) {
+        setState(() {
+          selectPage = currentPage;
+        });
+      }
+    });
+  }
 
   @override
   void dispose() {
@@ -72,22 +64,27 @@ class _OnBoardingViewState extends State<OnBoardingView> {
 
   void _handleNext() {
     if (selectPage < pageArr.length - 1) {
-      controller.nextPage(
-        duration: const Duration(milliseconds: 500),
-        curve: Curves.easeOutCubic,
+      final nextPage = selectPage + 1;
+      controller.animateToPage(
+        nextPage,
+        duration: const Duration(milliseconds: 600),
+        curve: Curves.easeInOut,
       );
+      setState(() {
+        selectPage = nextPage;
+      });
     } else {
-      context.go(AppRoute.signUp);
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) => const SignUpView(),
+        ),
+      );
     }
   }
 
   @override
   Widget build(BuildContext context) {
-    final totalPages = pageArr.length;
-    final progress = (selectPage + 1) / totalPages;
-
-    final isWelcome = pageArr[selectPage].isWelcome;
-
     return Scaffold(
       backgroundColor: TColor.white,
       body: Stack(
@@ -95,67 +92,50 @@ class _OnBoardingViewState extends State<OnBoardingView> {
         children: [
           PageView.builder(
             controller: controller,
-            itemCount: totalPages,
-            onPageChanged: (index) {
-              setState(() {
-                selectPage = index;
-              });
-            },
+            itemCount: pageArr.length,
             itemBuilder: (context, index) {
-              return OnBoardingPage(
-                content: pageArr[index],
-                onNext: _handleNext,
-              );
+              final pObj = pageArr[index];
+              return OnBoardingPage(pObj: pObj);
             },
           ),
-          if (!isWelcome)
-            Padding(
-              padding: const EdgeInsets.only(right: 24, bottom: 40),
-              child: SizedBox(
-                width: 120,
-                height: 120,
-                child: Stack(
-                  alignment: Alignment.center,
-                  children: [
-                    SizedBox(
-                      width: 80,
-                      height: 80,
-                      child: CircularProgressIndicator(
-                        color: TColor.primaryColor1,
-                        value: progress,
-                        strokeWidth: 3,
-                        backgroundColor: TColor.lightGray,
-                      ),
+          Padding(
+            padding: const EdgeInsets.only(right: 24, bottom: 32),
+            child: SizedBox(
+              width: 120,
+              height: 120,
+              child: Stack(
+                alignment: Alignment.center,
+                children: [
+                  SizedBox(
+                    width: 70,
+                    height: 70,
+                    child: CircularProgressIndicator(
+                      color: TColor.primaryColor1,
+                      value: (selectPage + 1) / pageArr.length,
+                      strokeWidth: 2,
                     ),
-                    Container(
-                      width: 70,
-                      height: 70,
-                      decoration: BoxDecoration(
-                        color: TColor.primaryColor1,
-                        borderRadius: BorderRadius.circular(40),
-                        boxShadow: [
-                          BoxShadow(
-                            color: TColor.primaryColor1.withValues(alpha: 0.3),
-                            blurRadius: 12,
-                            offset: const Offset(0, 6),
-                          ),
-                        ],
-                      ),
-                      child: IconButton(
-                        onPressed: _handleNext,
-                        icon: Icon(
-                          selectPage == totalPages - 1
-                              ? Icons.check_rounded
-                              : Icons.arrow_forward_rounded,
-                          color: TColor.white,
-                          size: 28,
-                        ),
-                      ),
+                  ),
+                  Container(
+                    width: 60,
+                    height: 60,
+                    decoration: BoxDecoration(
+                      color: TColor.primaryColor1,
+                      borderRadius: BorderRadius.circular(35),
                     ),
-                  ],
-                ),
+                    child: IconButton(
+                      icon: Icon(
+                        selectPage == pageArr.length - 1
+                            ? Icons.check
+                            : Icons.navigate_next,
+                        color: TColor.white,
+                      ),
+                      onPressed: _handleNext,
+                    ),
+                  ),
+                ],
               ),
             ),
+          ),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- restore the onboarding view to the original white background layout with the circular progress button in the corner
- reinstate the simple onboarding page widget that stacks the artwork, title, and subtitle content

## Testing
- not run (Flutter SDK not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7d1865b288333aaae063085266240