### PR TITLE
Add direct language toggle to onboarding

### DIFF
--- a/lib/view/on_boarding/on_boarding_view.dart
+++ b/lib/view/on_boarding/on_boarding_view.dart
@@ -12,33 +12,6 @@ class OnBoardingView extends StatefulWidget {
   State<OnBoardingView> createState() => _OnBoardingViewState();
 }
 
-class _LanguageToggleButton extends StatelessWidget {
-  const _LanguageToggleButton({
-    required this.language,
-    required this.onPressed,
-  });
-
-  final AppLanguage language;
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return OutlinedButton.icon(
-      style: OutlinedButton.styleFrom(
-        foregroundColor: TColor.primaryColor1,
-        side: BorderSide(color: TColor.primaryColor1),
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      ),
-      onPressed: onPressed,
-      icon: const Icon(Icons.language, size: 18),
-      label: Text(
-        language.buttonLabel,
-        style: const TextStyle(fontWeight: FontWeight.w600),
-      ),
-    );
-  }
-}
-
 class _OnBoardingViewState extends State<OnBoardingView> {
   final PageController _pageController = PageController();
   int _currentPageIndex = 0;
@@ -210,7 +183,7 @@ class _OnBoardingViewState extends State<OnBoardingView> {
             top: 16,
             right: 16,
             child: SafeArea(
-              child: _OnboardingLanguageMenu(
+              child: _OnboardingLanguageSwitcher(
                 selectedLanguage: _language,
                 onLanguageSelected: _updateLanguage,
               ),
@@ -222,8 +195,8 @@ class _OnBoardingViewState extends State<OnBoardingView> {
   }
 }
 
-class _OnboardingLanguageMenu extends StatelessWidget {
-  const _OnboardingLanguageMenu({
+class _OnboardingLanguageSwitcher extends StatelessWidget {
+  const _OnboardingLanguageSwitcher({
     required this.selectedLanguage,
     required this.onLanguageSelected,
   });
@@ -233,56 +206,57 @@ class _OnboardingLanguageMenu extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PopupMenuButton<AppLanguage>(
-      tooltip: 'Select language',
-      initialValue: selectedLanguage,
-      onSelected: onLanguageSelected,
-      itemBuilder: (context) {
-        return AppLanguage.values
+    final selections = AppLanguage.values
+        .map((language) => language == selectedLanguage)
+        .toList(growable: false);
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: TColor.white,
+        borderRadius: BorderRadius.circular(28),
+        boxShadow: [
+          BoxShadow(
+            color: TColor.primaryColor1.withValues(alpha: 0.12),
+            blurRadius: 12,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: ToggleButtons(
+        isSelected: selections,
+        onPressed: (index) {
+          final language = AppLanguage.values[index];
+          if (language != selectedLanguage) {
+            onLanguageSelected(language);
+          }
+        },
+        borderRadius: BorderRadius.circular(24),
+        borderColor: TColor.primaryColor1,
+        selectedBorderColor: TColor.primaryColor1,
+        color: TColor.primaryColor1,
+        selectedColor: TColor.white,
+        fillColor: TColor.primaryColor1,
+        splashColor: TColor.primaryColor2,
+        renderBorder: true,
+        constraints: const BoxConstraints(minHeight: 40, minWidth: 52),
+        children: AppLanguage.values
             .map(
-              (language) => PopupMenuItem<AppLanguage>(
-                value: language,
+              (language) => Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 12),
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    const Icon(Icons.translate, size: 18),
-                    const SizedBox(width: 8),
-                    Text(language.displayName),
-                    const Spacer(),
-                    if (language == selectedLanguage)
-                      Icon(Icons.check, color: TColor.primaryColor1, size: 18),
+                    const Icon(Icons.translate, size: 16),
+                    const SizedBox(width: 6),
+                    Text(
+                      language.buttonLabel,
+                      style: const TextStyle(fontWeight: FontWeight.w600),
+                    ),
                   ],
                 ),
               ),
             )
-            .toList();
-      },
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          border: Border.all(color: TColor.primaryColor1),
-          borderRadius: BorderRadius.circular(28),
-        ),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const Icon(
-                Icons.translate,
-                size: 18,
-                color: TColor.primaryColor1,
-              ),
-              const SizedBox(width: 8),
-              Text(
-                selectedLanguage.buttonLabel,
-                style: const TextStyle(
-                  color: TColor.primaryColor1,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ],
-          ),
-        ),
+            .toList(growable: false),
       ),
     );
   }
@@ -352,201 +326,6 @@ class _OnboardingProgressButton extends StatelessWidget {
               ),
             ),
           ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildProgressButton(int totalPages) {
-    final content = _pages[_currentPageIndex];
-    if (content.isWelcome) {
-      return const SizedBox.shrink();
-    }
-
-    final progress = (_currentPageIndex + 1) / totalPages;
-    final gradient = content.gradientColors ?? TColor.primaryG;
-
-    return Padding(
-      padding: const EdgeInsets.only(right: 24, bottom: 40),
-      child: SizedBox(
-        width: 88,
-        height: 88,
-        child: Stack(
-          alignment: Alignment.center,
-          children: [
-            SizedBox(
-              width: 72,
-              height: 72,
-              child: CircularProgressIndicator(
-                color: TColor.primaryColor1,
-                value: progress,
-                strokeWidth: 3,
-                backgroundColor: TColor.lightGray,
-              ),
-            ),
-            DecoratedBox(
-              decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  colors: gradient,
-                  begin: Alignment.topLeft,
-                  end: Alignment.bottomRight,
-                ),
-                shape: BoxShape.circle,
-                boxShadow: [
-                  BoxShadow(
-                    color: gradient.last.withValues(alpha: 0.3),
-                    blurRadius: 10,
-                    offset: const Offset(0, 6),
-                  ),
-                ],
-              ),
-              child: SizedBox(
-                width: 56,
-                height: 56,
-                child: IconButton(
-                  onPressed: _handleNext,
-                  icon: Icon(
-                    _currentPageIndex == totalPages - 1
-                        ? Icons.check_rounded
-                        : Icons.arrow_forward_rounded,
-                    color: TColor.white,
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _LanguageMenuButton extends StatelessWidget {
-  const _LanguageMenuButton({
-    required this.selectedLanguage,
-    required this.onLanguageSelected,
-  });
-
-  final AppLanguage selectedLanguage;
-  final ValueChanged<AppLanguage> onLanguageSelected;
-
-  @override
-  Widget build(BuildContext context) {
-    return PopupMenuButton<AppLanguage>(
-      tooltip: 'Select language',
-      initialValue: selectedLanguage,
-      onSelected: onLanguageSelected,
-      itemBuilder: (context) {
-        return AppLanguage.values
-            .map(
-              (language) => PopupMenuItem<AppLanguage>(
-                value: language,
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    const Icon(Icons.translate, size: 18),
-                    const SizedBox(width: 8),
-                    Text(language.displayName),
-                    const Spacer(),
-                    if (language == selectedLanguage)
-                      Icon(Icons.check, color: TColor.primaryColor1, size: 18),
-                  ],
-                ),
-              ),
-            )
-            .toList();
-      },
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          border: Border.all(color: TColor.primaryColor1),
-          borderRadius: BorderRadius.circular(28),
-        ),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const Icon(
-                Icons.translate,
-                size: 18,
-                color: TColor.primaryColor1,
-              ),
-              const SizedBox(width: 8),
-              Text(
-                selectedLanguage.buttonLabel,
-                style: const TextStyle(
-                  color: TColor.primaryColor1,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _LanguageMenuButton extends StatelessWidget {
-  const _LanguageMenuButton({
-    required this.selectedLanguage,
-    required this.onLanguageSelected,
-  });
-
-  final AppLanguage selectedLanguage;
-  final ValueChanged<AppLanguage> onLanguageSelected;
-
-  @override
-  Widget build(BuildContext context) {
-    return PopupMenuButton<AppLanguage>(
-      tooltip: 'Select language',
-      initialValue: selectedLanguage,
-      onSelected: onLanguageSelected,
-      itemBuilder: (context) {
-        return AppLanguage.values
-            .map(
-              (language) => PopupMenuItem<AppLanguage>(
-                value: language,
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    const Icon(Icons.translate, size: 18),
-                    const SizedBox(width: 8),
-                    Text(language.displayName),
-                    const Spacer(),
-                    if (language == selectedLanguage)
-                      Icon(Icons.check, color: TColor.primaryColor1, size: 18),
-                  ],
-                ),
-              ),
-            )
-            .toList();
-      },
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          border: Border.all(color: TColor.primaryColor1),
-          borderRadius: BorderRadius.circular(28),
-        ),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const Icon(
-                Icons.translate,
-                size: 18,
-                color: TColor.primaryColor1,
-              ),
-              const SizedBox(width: 8),
-              Text(
-                selectedLanguage.shortLabel,
-                style: const TextStyle(
-                  color: TColor.primaryColor1,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ],
-          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- replace the onboarding language popup menu with inline toggle buttons for instant switching between English and Indonesian
- keep the onboarding helpers streamlined and dependent on state-provided data

## Testing
- flutter analyze *(fails: Flutter is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e27e0887208333882802d7d1b46328