### PR TITLE
Remove redundant header comment from welcome view

### DIFF
--- a/lib/view/login/welcome_view.dart
+++ b/lib/view/login/welcome_view.dart
@@ -1,5 +1,3 @@
-// lib/view/login/welcome_view.dart
-
 import 'package:aigymbuddy/common/app_router.dart';
 import 'package:aigymbuddy/common/color_extension.dart';
 import 'package:aigymbuddy/common/localization/app_language.dart';


### PR DESCRIPTION
## Summary
- remove the redundant file header comment from the welcome view to keep the import list tidy

## Testing
- dart format lib/view/login/welcome_view.dart *(fails: `dart` command not available in environment)*
- flutter analyze *(fails: `flutter` command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a0b05b60833391858585c6c7dea0