### PR TITLE
Refine complete profile flow layout and localization

### DIFF
--- a/lib/common/localization/app_language_scope.dart
+++ b/lib/common/localization/app_language_scope.dart
@@ -1,0 +1,43 @@
+import 'package:aigymbuddy/common/localization/app_language.dart';
+import 'package:flutter/widgets.dart';
+
+/// Controller that stores the currently selected [AppLanguage].
+class AppLanguageController extends ChangeNotifier {
+  AppLanguage _language = AppLanguage.english;
+
+  AppLanguage get language => _language;
+
+  void select(AppLanguage language) {
+    if (language == _language) return;
+    _language = language;
+    notifyListeners();
+  }
+}
+
+/// Provides the [AppLanguageController] to the widget subtree.
+class AppLanguageScope extends InheritedNotifier<AppLanguageController> {
+  const AppLanguageScope({
+    super.key,
+    required AppLanguageController controller,
+    required super.child,
+  }) : super(notifier: controller);
+
+  static AppLanguageController of(BuildContext context) {
+    final scope =
+        context.dependOnInheritedWidgetOfExactType<AppLanguageScope>();
+    assert(scope != null, 'No AppLanguageScope found in context');
+    return scope!.notifier!;
+  }
+
+  static AppLanguage languageOf(BuildContext context) => of(context).language;
+
+  static String localizedText(BuildContext context, LocalizedText text) {
+    return text.resolve(languageOf(context));
+  }
+}
+
+extension AppLanguageContextX on BuildContext {
+  AppLanguage get appLanguage => AppLanguageScope.languageOf(this);
+
+  String localize(LocalizedText text) => text.resolve(appLanguage);
+}

--- a/lib/common_widget/app_language_toggle.dart
+++ b/lib/common_widget/app_language_toggle.dart
@@ -1,0 +1,72 @@
+import 'package:aigymbuddy/common/color_extension.dart';
+import 'package:aigymbuddy/common/localization/app_language.dart';
+import 'package:flutter/material.dart';
+
+/// Shared language toggle widget used across the onboarding and auth flows.
+class AppLanguageToggle extends StatelessWidget {
+  const AppLanguageToggle({
+    super.key,
+    required this.selectedLanguage,
+    required this.onSelected,
+  });
+
+  final AppLanguage selectedLanguage;
+  final ValueChanged<AppLanguage> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final selections = AppLanguage.values
+        .map((language) => language == selectedLanguage)
+        .toList(growable: false);
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: TColor.white,
+        borderRadius: BorderRadius.circular(28),
+        boxShadow: [
+          BoxShadow(
+            color: TColor.primaryColor1.withValues(alpha: 0.12),
+            blurRadius: 12,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: ToggleButtons(
+        isSelected: selections,
+        onPressed: (index) {
+          final language = AppLanguage.values[index];
+          if (language != selectedLanguage) {
+            onSelected(language);
+          }
+        },
+        borderRadius: BorderRadius.circular(24),
+        borderColor: TColor.primaryColor1,
+        selectedBorderColor: TColor.primaryColor1,
+        color: TColor.primaryColor1,
+        selectedColor: TColor.white,
+        fillColor: TColor.primaryColor1,
+        splashColor: TColor.primaryColor2,
+        renderBorder: true,
+        constraints: const BoxConstraints(minHeight: 40, minWidth: 52),
+        children: AppLanguage.values
+            .map(
+              (language) => Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Icon(Icons.translate, size: 16),
+                    const SizedBox(width: 6),
+                    Text(
+                      language.buttonLabel,
+                      style: const TextStyle(fontWeight: FontWeight.w600),
+                    ),
+                  ],
+                ),
+              ),
+            )
+            .toList(growable: false),
+      ),
+    );
+  }
+}

--- a/lib/common_widget/social_auth_button.dart
+++ b/lib/common_widget/social_auth_button.dart
@@ -1,0 +1,35 @@
+import 'package:aigymbuddy/common/color_extension.dart';
+import 'package:flutter/material.dart';
+
+/// Square social authentication button with rounded corners.
+class SocialAuthButton extends StatelessWidget {
+  const SocialAuthButton({
+    super.key,
+    required this.assetPath,
+    this.onTap,
+  });
+
+  final String assetPath;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        width: 50,
+        height: 50,
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: TColor.white,
+          border: Border.all(
+            width: 1,
+            color: TColor.gray.withValues(alpha: 0.4),
+          ),
+          borderRadius: BorderRadius.circular(15),
+        ),
+        child: Image.asset(assetPath, width: 20, height: 20),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,24 +1,41 @@
 import 'package:aigymbuddy/common/app_router.dart';
 import 'package:aigymbuddy/common/color_extension.dart';
+import 'package:aigymbuddy/common/localization/app_language_scope.dart';
 import 'package:flutter/material.dart';
 
 void main() {
   runApp(const MyApp());
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends StatefulWidget {
   const MyApp({super.key});
 
   @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  final AppLanguageController _languageController = AppLanguageController();
+
+  @override
+  void dispose() {
+    _languageController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return MaterialApp.router(
-      title: 'AI Gym Buddy',
-      debugShowCheckedModeBanner: false,
-      theme: ThemeData(
-        primaryColor: TColor.primaryColor1,
-        fontFamily: 'Poppins',
+    return AppLanguageScope(
+      controller: _languageController,
+      child: MaterialApp.router(
+        title: 'AI Gym Buddy',
+        debugShowCheckedModeBanner: false,
+        theme: ThemeData(
+          primaryColor: TColor.primaryColor1,
+          fontFamily: 'Poppins',
+        ),
+        routerConfig: AppRouter.router,
       ),
-      routerConfig: AppRouter.router,
     );
   }
 }

--- a/lib/view/login/complete_profile_view.dart
+++ b/lib/view/login/complete_profile_view.dart
@@ -1,12 +1,11 @@
-// lib/view/login/complete_profile_view.dart
-
 import 'package:aigymbuddy/common/app_router.dart';
 import 'package:aigymbuddy/common/color_extension.dart';
+import 'package:aigymbuddy/common/localization/app_language.dart';
+import 'package:aigymbuddy/common/localization/app_language_scope.dart';
+import 'package:aigymbuddy/common_widget/round_button.dart';
+import 'package:aigymbuddy/common_widget/round_textfield.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-
-import '../../common_widget/round_button.dart';
-import '../../common_widget/round_textfield.dart';
 
 class CompleteProfileView extends StatefulWidget {
   const CompleteProfileView({super.key});
@@ -16,16 +15,51 @@ class CompleteProfileView extends StatefulWidget {
 }
 
 class _CompleteProfileViewState extends State<CompleteProfileView> {
-  String? gender;
-  final TextEditingController dobCtrl = TextEditingController();
-  final TextEditingController weightCtrl = TextEditingController();
-  final TextEditingController heightCtrl = TextEditingController();
+  final TextEditingController _dobController = TextEditingController();
+  final TextEditingController _weightController = TextEditingController();
+  final TextEditingController _heightController = TextEditingController();
+  _Gender? _selectedGender;
+  static const _decimalKeyboard =
+      TextInputType.numberWithOptions(decimal: true);
+
+  static const _title = LocalizedText(
+    english: "Let’s complete your profile",
+    indonesian: 'Lengkapi profil Anda',
+  );
+  static const _subtitle = LocalizedText(
+    english: 'It will help us to know more about you!',
+    indonesian: 'Ini membantu kami mengenal Anda lebih baik!',
+  );
+  static const _genderHint = LocalizedText(
+    english: 'Choose Gender',
+    indonesian: 'Pilih Jenis Kelamin',
+  );
+  static const _dobHint = LocalizedText(
+    english: 'Date of Birth',
+    indonesian: 'Tanggal Lahir',
+  );
+  static const _dobHelpText = LocalizedText(
+    english: 'Select Date of Birth',
+    indonesian: 'Pilih Tanggal Lahir',
+  );
+  static const _weightHint = LocalizedText(
+    english: 'Your Weight',
+    indonesian: 'Berat Badan',
+  );
+  static const _heightHint = LocalizedText(
+    english: 'Your Height',
+    indonesian: 'Tinggi Badan',
+  );
+  static const _nextText = LocalizedText(
+    english: 'Next >',
+    indonesian: 'Berikutnya >',
+  );
 
   @override
   void dispose() {
-    dobCtrl.dispose();
-    weightCtrl.dispose();
-    heightCtrl.dispose();
+    _dobController.dispose();
+    _weightController.dispose();
+    _heightController.dispose();
     super.dispose();
   }
 
@@ -36,205 +70,199 @@ class _CompleteProfileViewState extends State<CompleteProfileView> {
       initialDate: DateTime(now.year - 18, now.month, now.day),
       firstDate: DateTime(now.year - 90),
       lastDate: now,
-      helpText: 'Select Date of Birth',
+      helpText: context.localize(_dobHelpText),
       builder: (context, child) {
-        // opsional: tema datepicker biar selaras
         return Theme(
           data: Theme.of(context).copyWith(
             colorScheme: ColorScheme.light(
-              primary: TColor.primaryColor1, // header background
-              onPrimary: TColor.white, // header text
-              onSurface: TColor.black, // body text
+              primary: TColor.primaryColor1,
+              onPrimary: TColor.white,
+              onSurface: TColor.black,
             ),
           ),
           child: child!,
         );
       },
     );
+
     if (picked != null) {
-      dobCtrl.text =
-          "${picked.year.toString().padLeft(4, '0')}-"
-          "${picked.month.toString().padLeft(2, '0')}-"
-          "${picked.day.toString().padLeft(2, '0')}";
+      _dobController.text =
+          '${picked.year.toString().padLeft(4, '0')}-'
+          '${picked.month.toString().padLeft(2, '0')}-'
+          '${picked.day.toString().padLeft(2, '0')}';
       setState(() {});
     }
+  }
+
+  void _onGenderChanged(_Gender? gender) {
+    setState(() {
+      _selectedGender = gender;
+    });
   }
 
   @override
   Widget build(BuildContext context) {
     final media = MediaQuery.of(context).size;
+    final localize = context.localize;
+    final title = localize(_title);
+    final subtitle = localize(_subtitle);
 
     return Scaffold(
       backgroundColor: TColor.white,
       body: SafeArea(
-        child: Center(
-          child: SingleChildScrollView(
-            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
-            child: ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 420), // presisi lebar
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  // Ilustrasi proporsional (tidak full lebar)
-                  Image.asset(
-                    "assets/img/complete_profile.png",
-                    width: media.width * 0.7,
-                    fit: BoxFit.contain,
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            return SingleChildScrollView(
+              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+              child: Center(
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(
+                    maxWidth: 420,
+                    minHeight: constraints.maxHeight,
                   ),
-
-                  const SizedBox(height: 24),
-
-                  // Title & subtitle
-                  Text(
-                    "Let’s complete your profile",
-                    textAlign: TextAlign.center,
-                    style: TextStyle(
-                      color: TColor.black,
-                      fontSize: 22,
-                      fontWeight: FontWeight.w700,
-                    ),
-                  ),
-                  const SizedBox(height: 6),
-                  Text(
-                    "It will help us to know more about you!",
-                    textAlign: TextAlign.center,
-                    style: TextStyle(color: TColor.gray, fontSize: 12),
-                  ),
-
-                  const SizedBox(height: 24),
-
-                  // Gender dropdown (card style)
-                  Container(
-                    height: 50,
-                    padding: const EdgeInsets.symmetric(horizontal: 12),
-                    decoration: BoxDecoration(
-                      color: TColor.lightGray,
-                      borderRadius: BorderRadius.circular(15),
-                    ),
-                    child: Row(
-                      children: [
-                        Image.asset(
-                          "assets/img/gender.png",
-                          width: 20,
-                          height: 20,
-                          color: TColor.gray,
-                        ),
-                        const SizedBox(width: 12),
-                        Expanded(
-                          child: DropdownButtonHideUnderline(
-                            child: DropdownButton<String>(
-                              isExpanded: true,
-                              value: gender,
-                              icon: Icon(
-                                Icons.keyboard_arrow_down_rounded,
-                                color: TColor.gray,
-                              ),
-                              items: const ["Male", "Female"]
-                                  .map(
-                                    (e) => DropdownMenuItem(
-                                      value: e,
-                                      child: Text(
-                                        e,
-                                        style: TextStyle(
-                                          color: TColor.gray,
-                                          fontSize: 14,
-                                        ),
-                                      ),
-                                    ),
-                                  )
-                                  .toList(),
-                              hint: Text(
-                                "Choose Gender",
-                                style: TextStyle(
-                                  color: TColor.gray,
-                                  fontSize: 12,
-                                ),
-                              ),
-                              onChanged: (v) => setState(() => gender = v),
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-
-                  const SizedBox(height: 16),
-
-                  // Date of Birth (tap open picker)
-                  GestureDetector(
-                    onTap: _pickDob,
-                    behavior: HitTestBehavior.opaque,
-                    child: AbsorbPointer(
-                      child: RoundTextField(
-                        controller: dobCtrl,
-                        hitText: "Date of Birth",
-                        icon: "assets/img/date.png",
-                      ),
-                    ),
-                  ),
-
-                  const SizedBox(height: 16),
-
-                  // Weight
-                  Row(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
-                      Expanded(
-                        child: RoundTextField(
-                          controller: weightCtrl,
-                          hitText: "Your Weight",
-                          icon: "assets/img/weight.png",
-                          keyboardType: const TextInputType.numberWithOptions(
-                            decimal: true,
+                      const SizedBox(height: 16),
+                      Image.asset(
+                        'assets/img/complete_profile.png',
+                        width: media.width * 0.65,
+                        fit: BoxFit.contain,
+                      ),
+                      const SizedBox(height: 24),
+                      _Header(title: title, subtitle: subtitle),
+                      const SizedBox(height: 24),
+                      _buildGenderField(context),
+                      const SizedBox(height: 16),
+                      GestureDetector(
+                        onTap: _pickDob,
+                        behavior: HitTestBehavior.opaque,
+                        child: AbsorbPointer(
+                          child: RoundTextField(
+                            controller: _dobController,
+                            hitText: context.localize(_dobHint),
+                            icon: 'assets/img/date.png',
                           ),
                         ),
                       ),
-                      const SizedBox(width: 8),
-                      _UnitTag(text: "KG"),
+                      const SizedBox(height: 16),
+                      _buildMeasurementField(
+                        context,
+                        controller: _weightController,
+                        hint: _weightHint,
+                        iconAsset: 'assets/img/weight.png',
+                        unit: 'KG',
+                      ),
+                      const SizedBox(height: 16),
+                      _buildMeasurementField(
+                        context,
+                        controller: _heightController,
+                        hint: _heightHint,
+                        iconAsset: 'assets/img/hight.png',
+                        unit: 'CM',
+                      ),
+                      const SizedBox(height: 28),
+                      RoundButton(
+                        title: localize(_nextText),
+                        onPressed: () {
+                          context.push(AppRoute.goal);
+                        },
+                      ),
                     ],
                   ),
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
 
-                  const SizedBox(height: 16),
-
-                  // Height
-                  Row(
-                    children: [
-                      Expanded(
-                        child: RoundTextField(
-                          controller: heightCtrl,
-                          hitText: "Your Height",
-                          icon: "assets/img/hight.png",
-                          keyboardType: const TextInputType.numberWithOptions(
-                            decimal: true,
+  Widget _buildGenderField(BuildContext context) {
+    return Container(
+      height: 50,
+      padding: const EdgeInsets.symmetric(horizontal: 12),
+      decoration: BoxDecoration(
+        color: TColor.lightGray,
+        borderRadius: BorderRadius.circular(15),
+      ),
+      child: Row(
+        children: [
+          Image.asset(
+            'assets/img/gender.png',
+            width: 20,
+            height: 20,
+            color: TColor.gray,
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: DropdownButtonHideUnderline(
+              child: DropdownButton<_Gender>(
+                isExpanded: true,
+                value: _selectedGender,
+                hint: Text(
+                  context.localize(_genderHint),
+                  style: TextStyle(
+                    color: TColor.gray,
+                    fontSize: 12,
+                  ),
+                ),
+                icon: Icon(
+                  Icons.keyboard_arrow_down_rounded,
+                  color: TColor.gray,
+                ),
+                items: _Gender.values
+                    .map(
+                      (gender) => DropdownMenuItem<_Gender>(
+                        value: gender,
+                        child: Text(
+                          context.localize(gender.label),
+                          style: TextStyle(
+                            color: TColor.gray,
+                            fontSize: 14,
                           ),
                         ),
                       ),
-                      const SizedBox(width: 8),
-                      _UnitTag(text: "CM"),
-                    ],
-                  ),
-
-                  const SizedBox(height: 28),
-
-                  // Button Next
-                  RoundButton(
-                    title: "Next >",
-                    onPressed: () {
-                      context.push(AppRoute.goal);
-                    },
-                  ),
-                ],
+                    )
+                    .toList(),
+                onChanged: _onGenderChanged,
               ),
             ),
           ),
-        ),
+        ],
       ),
+    );
+  }
+
+  Widget _buildMeasurementField(
+    BuildContext context, {
+    required TextEditingController controller,
+    required LocalizedText hint,
+    required String iconAsset,
+    required String unit,
+  }) {
+    return Row(
+      children: [
+        Expanded(
+          child: RoundTextField(
+            controller: controller,
+            hitText: context.localize(hint),
+            icon: iconAsset,
+            keyboardType: _decimalKeyboard,
+          ),
+        ),
+        const SizedBox(width: 8),
+        _UnitTag(text: unit),
+      ],
     );
   }
 }
 
 class _UnitTag extends StatelessWidget {
-  final String text;
   const _UnitTag({required this.text});
+
+  final String text;
 
   @override
   Widget build(BuildContext context) {
@@ -253,7 +281,51 @@ class _UnitTag extends StatelessWidget {
           ),
         ],
       ),
-      child: Text(text, style: TextStyle(color: TColor.white, fontSize: 12)),
+      child: Text(
+        text,
+        style: TextStyle(color: TColor.white, fontSize: 12),
+      ),
     );
   }
+}
+
+class _Header extends StatelessWidget {
+  const _Header({required this.title, required this.subtitle});
+
+  final String title;
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text(
+          title,
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            color: TColor.black,
+            fontSize: 22,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        const SizedBox(height: 6),
+        Text(
+          subtitle,
+          textAlign: TextAlign.center,
+          style: TextStyle(color: TColor.gray, fontSize: 12),
+        ),
+      ],
+    );
+  }
+}
+
+enum _Gender { male, female }
+
+extension on _Gender {
+  LocalizedText get label => switch (this) {
+        _Gender.male => const LocalizedText(
+            english: 'Male', indonesian: 'Pria'),
+        _Gender.female => const LocalizedText(
+            english: 'Female', indonesian: 'Wanita'),
+      };
 }

--- a/lib/view/login/login_view.dart
+++ b/lib/view/login/login_view.dart
@@ -1,193 +1,215 @@
-// lib/view/login/loign_view.dart
-
 import 'package:aigymbuddy/common/app_router.dart';
 import 'package:aigymbuddy/common/color_extension.dart';
+import 'package:aigymbuddy/common/localization/app_language.dart';
+import 'package:aigymbuddy/common/localization/app_language_scope.dart';
 import 'package:aigymbuddy/common_widget/round_button.dart';
 import 'package:aigymbuddy/common_widget/round_textfield.dart';
+import 'package:aigymbuddy/common_widget/social_auth_button.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
-class LoginView extends StatefulWidget {
+class LoginView extends StatelessWidget {
   const LoginView({super.key});
 
-  @override
-  State<LoginView> createState() => _LoginViewState();
-}
+  static const _socialProviders = [
+    'assets/img/google.png',
+    'assets/img/facebook.png',
+  ];
 
-class _LoginViewState extends State<LoginView> {
-  bool isCheck = false;
+  static const _greetingText = LocalizedText(
+    english: 'Hey there,',
+    indonesian: 'Hai,',
+  );
+  static const _welcomeBackText = LocalizedText(
+    english: 'Welcome Back',
+    indonesian: 'Selamat Datang Kembali',
+  );
+  static const _emailHint = LocalizedText(
+    english: 'Email',
+    indonesian: 'Email',
+  );
+  static const _passwordHint = LocalizedText(
+    english: 'Password',
+    indonesian: 'Kata Sandi',
+  );
+  static const _forgotPasswordText = LocalizedText(
+    english: 'Forgot your password?',
+    indonesian: 'Lupa kata sandi?',
+  );
+  static const _loginButtonText = LocalizedText(
+    english: 'Login',
+    indonesian: 'Masuk',
+  );
+  static const _dividerText = LocalizedText(
+    english: 'Or',
+    indonesian: 'Atau',
+  );
+  static const _noAccountText = LocalizedText(
+    english: 'Don’t have an account yet? ',
+    indonesian: 'Belum punya akun? ',
+  );
+  static const _registerText = LocalizedText(
+    english: 'Register',
+    indonesian: 'Daftar',
+  );
+
   @override
   Widget build(BuildContext context) {
-    var media = MediaQuery.of(context).size;
     return Scaffold(
       backgroundColor: TColor.white,
-      body: SingleChildScrollView(
-        child: SafeArea(
-          child: Container(
-            height: media.height * 0.9,
-            padding: const EdgeInsets.symmetric(horizontal: 20),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                Text(
-                  "Hey there,",
-                  style: TextStyle(color: TColor.gray, fontSize: 16),
-                ),
-                Text(
-                  "Welcome Back",
-                  style: TextStyle(
-                    color: TColor.black,
-                    fontSize: 20,
-                    fontWeight: FontWeight.w700,
+      body: SafeArea(
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            return SingleChildScrollView(
+              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+              child: Center(
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(
+                    maxWidth: 420,
+                    minHeight: constraints.maxHeight,
                   ),
-                ),
-                SizedBox(height: media.width * 0.05),
-                SizedBox(height: media.width * 0.04),
-                const RoundTextField(
-                  hitText: "Email",
-                  icon: "assets/img/email.png",
-                  keyboardType: TextInputType.emailAddress,
-                ),
-                SizedBox(height: media.width * 0.04),
-                RoundTextField(
-                  hitText: "Password",
-                  icon: "assets/img/lock.png",
-                  obscureText: true,
-                  rigtIcon: TextButton(
-                    onPressed: () {},
-                    child: Container(
-                      alignment: Alignment.center,
-                      width: 20,
-                      height: 20,
-                      child: Image.asset(
-                        "assets/img/show_password.png",
-                        width: 20,
-                        height: 20,
-                        fit: BoxFit.contain,
-                        color: TColor.gray,
-                      ),
-                    ),
-                  ),
-                ),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Text(
-                      "Forgot your password?",
-                      style: TextStyle(
-                        color: TColor.gray,
-                        fontSize: 10,
-                        decoration: TextDecoration.underline,
-                      ),
-                    ),
-                  ],
-                ),
-                const Spacer(),
-                RoundButton(
-                  title: "Login",
-                  onPressed: () {
-                    context.push(AppRoute.completeProfile);
-                  },
-                ),
-                SizedBox(height: media.width * 0.04),
-                Row(
-                  // crossAxisAlignment: CrossAxisAlignment.,
-                  children: [
-                    Expanded(
-                      child: Container(
-                        height: 1,
-                        color: TColor.gray.withValues(alpha: 0.5),
-                      ),
-                    ),
-                    Text(
-                      "  Or  ",
-                      style: TextStyle(color: TColor.black, fontSize: 12),
-                    ),
-                    Expanded(
-                      child: Container(
-                        height: 1,
-                        color: TColor.gray.withValues(alpha: 0.5),
-                      ),
-                    ),
-                  ],
-                ),
-                SizedBox(height: media.width * 0.04),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    GestureDetector(
-                      onTap: () {},
-                      child: Container(
-                        width: 50,
-                        height: 50,
-                        alignment: Alignment.center,
-                        decoration: BoxDecoration(
-                          color: TColor.white,
-                          border: Border.all(
-                            width: 1,
-                            color: TColor.gray.withValues(alpha: 0.5),
-                          ),
-                          borderRadius: BorderRadius.circular(15),
-                        ),
-                        child: Image.asset(
-                          "assets/img/google.png",
-                          width: 20,
-                          height: 20,
-                        ),
-                      ),
-                    ),
-                    SizedBox(width: media.width * 0.04),
-                    GestureDetector(
-                      onTap: () {},
-                      child: Container(
-                        width: 50,
-                        height: 50,
-                        alignment: Alignment.center,
-                        decoration: BoxDecoration(
-                          color: TColor.white,
-                          border: Border.all(
-                            width: 1,
-                            color: TColor.gray.withValues(alpha: 0.4),
-                          ),
-                          borderRadius: BorderRadius.circular(15),
-                        ),
-                        child: Image.asset(
-                          "assets/img/facebook.png",
-                          width: 20,
-                          height: 20,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-                SizedBox(height: media.width * 0.04),
-                TextButton(
-                  onPressed: () {
-                    context.pop();
-                  },
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
+                      const SizedBox(height: 24),
                       Text(
-                        "Don’t have an account yet? ",
-                        style: TextStyle(color: TColor.black, fontSize: 14),
+                        context.localize(_greetingText),
+                        textAlign: TextAlign.center,
+                        style: TextStyle(color: TColor.gray, fontSize: 16),
                       ),
+                      const SizedBox(height: 6),
                       Text(
-                        "Register",
+                        context.localize(_welcomeBackText),
+                        textAlign: TextAlign.center,
                         style: TextStyle(
                           color: TColor.black,
-                          fontSize: 14,
+                          fontSize: 24,
                           fontWeight: FontWeight.w700,
                         ),
                       ),
+                      const SizedBox(height: 36),
+                      RoundTextField(
+                        hitText: context.localize(_emailHint),
+                        icon: 'assets/img/email.png',
+                        keyboardType: TextInputType.emailAddress,
+                      ),
+                      const SizedBox(height: 20),
+                      RoundTextField(
+                        hitText: context.localize(_passwordHint),
+                        icon: 'assets/img/lock.png',
+                        obscureText: true,
+                        rigtIcon: IconButton(
+                          padding: EdgeInsets.zero,
+                          constraints: const BoxConstraints(),
+                          onPressed: () {},
+                          icon: Image.asset(
+                            'assets/img/show_password.png',
+                            width: 20,
+                            height: 20,
+                            color: TColor.gray,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+                      Align(
+                        alignment: Alignment.centerRight,
+                        child: TextButton(
+                          onPressed: () {},
+                          style: TextButton.styleFrom(
+                            padding: EdgeInsets.zero,
+                            minimumSize: const Size(0, 0),
+                            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                          ),
+                          child: Text(
+                            context.localize(_forgotPasswordText),
+                            style: TextStyle(
+                              color: TColor.gray,
+                              fontSize: 12,
+                              decoration: TextDecoration.underline,
+                            ),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 28),
+                      RoundButton(
+                        title: context.localize(_loginButtonText),
+                        onPressed: () {
+                          context.push(AppRoute.completeProfile);
+                        },
+                      ),
+                      const SizedBox(height: 28),
+                      Row(
+                        children: [
+                          Expanded(
+                            child: Container(
+                              height: 1,
+                              color: TColor.gray.withValues(alpha: 0.5),
+                            ),
+                          ),
+                          Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 12),
+                            child: Text(
+                              context.localize(_dividerText),
+                              style: TextStyle(color: TColor.black, fontSize: 12),
+                            ),
+                          ),
+                          Expanded(
+                            child: Container(
+                              height: 1,
+                              color: TColor.gray.withValues(alpha: 0.5),
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 24),
+                      _buildSocialRow(),
+                      const SizedBox(height: 28),
+                      _buildSignUpPrompt(context),
                     ],
                   ),
                 ),
-                SizedBox(height: media.width * 0.04),
-              ],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSocialRow() {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        for (var i = 0; i < _socialProviders.length; i++) ...[
+          SocialAuthButton(assetPath: _socialProviders[i]),
+          if (i < _socialProviders.length - 1) const SizedBox(width: 16),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildSignUpPrompt(BuildContext context) {
+    return TextButton(
+      onPressed: () {
+        context.go(AppRoute.signUp);
+      },
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            context.localize(_noAccountText),
+            style: TextStyle(color: TColor.black, fontSize: 14),
+          ),
+          Text(
+            context.localize(_registerText),
+            style: TextStyle(
+              color: TColor.black,
+              fontSize: 14,
+              fontWeight: FontWeight.w700,
             ),
           ),
-        ),
+        ],
       ),
     );
   }

--- a/lib/view/login/signup_view.dart
+++ b/lib/view/login/signup_view.dart
@@ -2,8 +2,11 @@
 
 import 'package:aigymbuddy/common/app_router.dart';
 import 'package:aigymbuddy/common/color_extension.dart';
+import 'package:aigymbuddy/common/localization/app_language.dart';
+import 'package:aigymbuddy/common/localization/app_language_scope.dart';
 import 'package:aigymbuddy/common_widget/round_button.dart';
 import 'package:aigymbuddy/common_widget/round_textfield.dart';
+import 'package:aigymbuddy/common_widget/social_auth_button.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
@@ -15,7 +18,54 @@ class SignUpView extends StatefulWidget {
 }
 
 class _SignUpViewState extends State<SignUpView> {
-  bool isCheck = false;
+  bool _isTermsAccepted = false;
+
+  static const _greetingText = LocalizedText(
+    english: 'Hey there,',
+    indonesian: 'Hai,',
+  );
+  static const _createAccountText = LocalizedText(
+    english: 'Create an Account',
+    indonesian: 'Buat Akun',
+  );
+  static const _firstNameHint = LocalizedText(
+    english: 'First Name',
+    indonesian: 'Nama Depan',
+  );
+  static const _lastNameHint = LocalizedText(
+    english: 'Last Name',
+    indonesian: 'Nama Belakang',
+  );
+  static const _emailHint = LocalizedText(
+    english: 'Email',
+    indonesian: 'Email',
+  );
+  static const _passwordHint = LocalizedText(
+    english: 'Password',
+    indonesian: 'Kata Sandi',
+  );
+  static const _termsText = LocalizedText(
+    english:
+        'By continuing you accept our Privacy Policy and\nTerm of Use',
+    indonesian:
+        'Dengan melanjutkan kamu menyetujui Kebijakan Privasi dan\nSyarat Penggunaan kami',
+  );
+  static const _registerText = LocalizedText(
+    english: 'Register',
+    indonesian: 'Daftar',
+  );
+  static const _dividerText = LocalizedText(
+    english: 'Or',
+    indonesian: 'Atau',
+  );
+  static const _footerQuestionText = LocalizedText(
+    english: 'Already have an account? ',
+    indonesian: 'Sudah punya akun? ',
+  );
+  static const _footerActionText = LocalizedText(
+    english: 'Login',
+    indonesian: 'Masuk',
+  );
 
   @override
   Widget build(BuildContext context) {
@@ -24,29 +74,27 @@ class _SignUpViewState extends State<SignUpView> {
       body: SafeArea(
         child: LayoutBuilder(
           builder: (context, constraints) {
-            return Center(
-              child: SingleChildScrollView(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 20,
-                  vertical: 24,
-                ),
+            return SingleChildScrollView(
+              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+              child: Center(
                 child: ConstrainedBox(
-                  constraints: const BoxConstraints(
+                  constraints: BoxConstraints(
                     maxWidth: 420,
-                  ), // presisi max width
+                    minHeight: constraints.maxHeight,
+                  ),
                   child: Column(
-                    crossAxisAlignment:
-                        CrossAxisAlignment.stretch, // full-width
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    mainAxisAlignment: MainAxisAlignment.center,
                     children: [
-                      // Header
+                      const SizedBox(height: 24),
                       Text(
-                        "Hey there,",
+                        context.localize(_greetingText),
                         textAlign: TextAlign.center,
                         style: TextStyle(color: TColor.gray, fontSize: 16),
                       ),
                       const SizedBox(height: 4),
                       Text(
-                        "Create an Account",
+                        context.localize(_createAccountText),
                         textAlign: TextAlign.center,
                         style: TextStyle(
                           color: TColor.black,
@@ -54,35 +102,33 @@ class _SignUpViewState extends State<SignUpView> {
                           fontWeight: FontWeight.w700,
                         ),
                       ),
-                      const SizedBox(height: 24),
-
-                      // Fields
-                      const RoundTextField(
-                        hitText: "First Name",
-                        icon: "assets/img/user_text.png",
+                      const SizedBox(height: 28),
+                      RoundTextField(
+                        hitText: context.localize(_firstNameHint),
+                        icon: 'assets/img/user_text.png',
                       ),
                       const SizedBox(height: 16),
-                      const RoundTextField(
-                        hitText: "Last Name",
-                        icon: "assets/img/user_text.png",
+                      RoundTextField(
+                        hitText: context.localize(_lastNameHint),
+                        icon: 'assets/img/user_text.png',
                       ),
                       const SizedBox(height: 16),
-                      const RoundTextField(
-                        hitText: "Email",
-                        icon: "assets/img/email.png",
+                      RoundTextField(
+                        hitText: context.localize(_emailHint),
+                        icon: 'assets/img/email.png',
                         keyboardType: TextInputType.emailAddress,
                       ),
                       const SizedBox(height: 16),
                       RoundTextField(
-                        hitText: "Password",
-                        icon: "assets/img/lock.png",
+                        hitText: context.localize(_passwordHint),
+                        icon: 'assets/img/lock.png',
                         obscureText: true,
                         rigtIcon: IconButton(
                           padding: EdgeInsets.zero,
                           constraints: const BoxConstraints(),
                           onPressed: () {},
                           icon: Image.asset(
-                            "assets/img/show_password.png",
+                            'assets/img/show_password.png',
                             width: 20,
                             height: 20,
                             color: TColor.gray,
@@ -90,15 +136,16 @@ class _SignUpViewState extends State<SignUpView> {
                         ),
                       ),
                       const SizedBox(height: 12),
-
-                      // Checkbox rapi tanpa IconButton
                       Row(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           Checkbox(
-                            value: isCheck,
-                            onChanged: (v) =>
-                                setState(() => isCheck = v ?? false),
+                            value: _isTermsAccepted,
+                            onChanged: (value) {
+                              setState(() {
+                                _isTermsAccepted = value ?? false;
+                              });
+                            },
                             visualDensity: VisualDensity.compact,
                             materialTapTargetSize:
                                 MaterialTapTargetSize.shrinkWrap,
@@ -106,7 +153,7 @@ class _SignUpViewState extends State<SignUpView> {
                           const SizedBox(width: 4),
                           Expanded(
                             child: Text(
-                              "By continuing you accept our Privacy Policy and\nTerm of Use",
+                              context.localize(_termsText),
                               style: TextStyle(
                                 color: TColor.gray,
                                 fontSize: 12,
@@ -115,20 +162,14 @@ class _SignUpViewState extends State<SignUpView> {
                           ),
                         ],
                       ),
-
                       const SizedBox(height: 24),
-
-                      // Button full-width
                       RoundButton(
-                        title: "Register",
+                        title: context.localize(_registerText),
                         onPressed: () {
                           context.push(AppRoute.completeProfile);
                         },
                       ),
-
                       const SizedBox(height: 16),
-
-                      // Divider "Or"
                       Row(
                         children: [
                           Expanded(
@@ -139,7 +180,7 @@ class _SignUpViewState extends State<SignUpView> {
                           ),
                           const SizedBox(width: 8),
                           Text(
-                            "Or",
+                            context.localize(_dividerText),
                             style: TextStyle(color: TColor.black, fontSize: 12),
                           ),
                           const SizedBox(width: 8),
@@ -151,22 +192,16 @@ class _SignUpViewState extends State<SignUpView> {
                           ),
                         ],
                       ),
-
                       const SizedBox(height: 16),
-
-                      // Socials
                       Row(
                         mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          _SocialIcon(path: "assets/img/google.png"),
-                          const SizedBox(width: 12),
-                          _SocialIcon(path: "assets/img/facebook.png"),
+                        children: const [
+                          SocialAuthButton(assetPath: 'assets/img/google.png'),
+                          SizedBox(width: 16),
+                          SocialAuthButton(assetPath: 'assets/img/facebook.png'),
                         ],
                       ),
-
                       const SizedBox(height: 20),
-
-                      // Footer link
                       TextButton(
                         onPressed: () {
                           context.push(AppRoute.login);
@@ -175,14 +210,12 @@ class _SignUpViewState extends State<SignUpView> {
                           mainAxisSize: MainAxisSize.min,
                           children: [
                             Text(
-                              "Already have an account? ",
-                              style: TextStyle(
-                                color: TColor.black,
-                                fontSize: 14,
-                              ),
+                              context.localize(_footerQuestionText),
+                              style:
+                                  TextStyle(color: TColor.black, fontSize: 14),
                             ),
                             Text(
-                              "Login",
+                              context.localize(_footerActionText),
                               style: TextStyle(
                                 color: TColor.black,
                                 fontSize: 14,
@@ -192,6 +225,7 @@ class _SignUpViewState extends State<SignUpView> {
                           ],
                         ),
                       ),
+                      const SizedBox(height: 24),
                     ],
                   ),
                 ),
@@ -199,32 +233,6 @@ class _SignUpViewState extends State<SignUpView> {
             );
           },
         ),
-      ),
-    );
-  }
-}
-
-class _SocialIcon extends StatelessWidget {
-  final String path;
-  const _SocialIcon({required this.path});
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: () {},
-      child: Container(
-        width: 50,
-        height: 50,
-        alignment: Alignment.center,
-        decoration: BoxDecoration(
-          color: TColor.white,
-          border: Border.all(
-            width: 1,
-            color: TColor.gray.withValues(alpha: 0.4),
-          ),
-          borderRadius: BorderRadius.circular(15),
-        ),
-        child: Image.asset(path, width: 20, height: 20),
       ),
     );
   }

--- a/lib/view/login/welcome_view.dart
+++ b/lib/view/login/welcome_view.dart
@@ -1,11 +1,13 @@
 // lib/view/login/welcome_view.dart
 
 import 'package:aigymbuddy/common/app_router.dart';
+import 'package:aigymbuddy/common/color_extension.dart';
+import 'package:aigymbuddy/common/localization/app_language.dart';
+import 'package:aigymbuddy/common/localization/app_language_scope.dart';
 import 'package:aigymbuddy/common/services/auth_service.dart';
+import 'package:aigymbuddy/common_widget/round_button.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import '../../common/color_extension.dart';
-import '../../common_widget/round_button.dart';
 
 class WelcomeView extends StatefulWidget {
   const WelcomeView({super.key});
@@ -15,52 +17,73 @@ class WelcomeView extends StatefulWidget {
 }
 
 class _WelcomeViewState extends State<WelcomeView> {
+  static const _title = LocalizedText(
+    english: 'Welcome, GYM Buddy',
+    indonesian: 'Selamat datang, GYM Buddy',
+  );
+  static const _subtitle = LocalizedText(
+    english:
+        'You are all set now, let’s reach your\ngoals together with us',
+    indonesian:
+        'Semua sudah siap, ayo capai\ntujuanmu bersama kami',
+  );
+  static const _cta = LocalizedText(
+    english: 'Go To Home',
+    indonesian: 'Pergi ke Beranda',
+  );
+
   @override
   Widget build(BuildContext context) {
-    var media = MediaQuery.of(context).size;
     return Scaffold(
       backgroundColor: TColor.white,
       body: SafeArea(
-        child: Container(
-          width: media.width,
-          padding: const EdgeInsets.symmetric(vertical: 15, horizontal: 25),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            mainAxisSize: MainAxisSize.max,
-            children: [
-              SizedBox(height: media.width * 0.1),
-              Image.asset(
-                "assets/img/welcome.png",
-                width: media.width * 0.75,
-                fit: BoxFit.fitWidth,
-              ),
-              SizedBox(height: media.width * 0.1),
-              Text(
-                "Welcome, GYM Buddy",
-                style: TextStyle(
-                  color: TColor.black,
-                  fontSize: 20,
-                  fontWeight: FontWeight.w700,
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            return SingleChildScrollView(
+              padding:
+                  const EdgeInsets.symmetric(vertical: 16, horizontal: 24),
+              child: ConstrainedBox(
+                constraints: BoxConstraints(minHeight: constraints.maxHeight),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const SizedBox(height: 32),
+                    Image.asset(
+                      'assets/img/welcome.png',
+                      width: MediaQuery.of(context).size.width * 0.75,
+                      fit: BoxFit.fitWidth,
+                    ),
+                    const SizedBox(height: 32),
+                    Text(
+                      context.localize(_title),
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                        color: TColor.black,
+                        fontSize: 24,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    Text(
+                      context.localize(_subtitle),
+                      textAlign: TextAlign.center,
+                      style: TextStyle(color: TColor.gray, fontSize: 14),
+                    ),
+                    const SizedBox(height: 40),
+                    RoundButton(
+                      title: context.localize(_cta),
+                      onPressed: () async {
+                        final router = GoRouter.of(context);
+                        await AuthService.instance.setHasCredentials(true);
+                        if (!mounted) return;
+                        router.go(AppRoute.main);
+                      },
+                    ),
+                  ],
                 ),
               ),
-              Text(
-                "You are all set now, let’s reach your\ngoals together with us",
-                textAlign: TextAlign.center,
-                style: TextStyle(color: TColor.gray, fontSize: 12),
-              ),
-              const Spacer(),
-
-              RoundButton(
-                title: "Go To Home",
-                onPressed: () async {
-                  final router = GoRouter.of(context);
-                  await AuthService.instance.setHasCredentials(true);
-                  if (!mounted) return;
-                  router.go(AppRoute.main);
-                },
-              ),
-            ],
-          ),
+            );
+          },
         ),
       ),
     );

--- a/lib/view/login/what_your_goal_view.dart
+++ b/lib/view/login/what_your_goal_view.dart
@@ -1,42 +1,70 @@
-// lib/view/login_what_your_goal_view.dart
+// lib/view/login/what_your_goal_view.dart
 
 import 'package:aigymbuddy/common/app_router.dart';
+import 'package:aigymbuddy/common/color_extension.dart';
+import 'package:aigymbuddy/common/localization/app_language.dart';
+import 'package:aigymbuddy/common/localization/app_language_scope.dart';
+import 'package:aigymbuddy/common_widget/round_button.dart';
 import 'package:carousel_slider/carousel_slider.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../common/color_extension.dart';
-import '../../common_widget/round_button.dart';
-
-class WhatYourGoalView extends StatefulWidget {
+class WhatYourGoalView extends StatelessWidget {
   const WhatYourGoalView({super.key});
 
-  @override
-  State<WhatYourGoalView> createState() => _WhatYourGoalViewState();
-}
+  static const _title = LocalizedText(
+    english: 'What is your goal?',
+    indonesian: 'Apa tujuanmu?',
+  );
+  static const _subtitle = LocalizedText(
+    english: 'It will help us to choose a best program for you',
+    indonesian: 'Ini membantu kami memilih program terbaik untukmu',
+  );
+  static const _confirmText = LocalizedText(
+    english: 'Confirm',
+    indonesian: 'Konfirmasi',
+  );
 
-class _WhatYourGoalViewState extends State<WhatYourGoalView> {
-  final CarouselSliderController _controller = CarouselSliderController();
-
-  final List<Map<String, String>> goalArr = [
-    {
-      "image": "assets/img/goal_1.png",
-      "title": "Improve Shape",
-      "subtitle":
-          "I have a low amount of body fat and\nneed / want to build more muscle",
-    },
-    {
-      "image": "assets/img/goal_2.png",
-      "title": "Lean & Tone",
-      "subtitle":
-          "I’m “skinny fat”, look thin but have\nno shape. I want to add lean muscle\nin the right way",
-    },
-    {
-      "image": "assets/img/goal_3.png",
-      "title": "Lose a Fat",
-      "subtitle":
-          "I have over 20 lbs to lose. I want to\ndrop all this fat and gain muscle mass",
-    },
+  static const List<_GoalCardData> _goals = [
+    _GoalCardData(
+      image: 'assets/img/goal_1.png',
+      title: LocalizedText(
+        english: 'Improve Shape',
+        indonesian: 'Bentuk Tubuh Ideal',
+      ),
+      subtitle: LocalizedText(
+        english:
+            'I have a low amount of body fat and\nneed / want to build more muscle',
+        indonesian:
+            'Lemak tubuhku rendah dan aku ingin\nmembangun lebih banyak otot',
+      ),
+    ),
+    _GoalCardData(
+      image: 'assets/img/goal_2.png',
+      title: LocalizedText(
+        english: 'Lean & Tone',
+        indonesian: 'Badan Ramping & Kencang',
+      ),
+      subtitle: LocalizedText(
+        english:
+            'I’m “skinny fat”, look thin but have\nno shape. I want to add lean muscle\nin the right way',
+        indonesian:
+            'Tubuhku tampak kurus tapi kurang berisi.\nAku ingin menambah otot tanpa lemak\ndengan cara tepat',
+      ),
+    ),
+    _GoalCardData(
+      image: 'assets/img/goal_3.png',
+      title: LocalizedText(
+        english: 'Lose a Fat',
+        indonesian: 'Turunkan Lemak',
+      ),
+      subtitle: LocalizedText(
+        english:
+            'I have over 20 lbs to lose. I want to\ndrop all this fat and gain muscle mass',
+        indonesian:
+            'Aku perlu menurunkan banyak lemak\ndan ingin menambah massa otot',
+      ),
+    ),
   ];
 
   @override
@@ -51,32 +79,28 @@ class _WhatYourGoalViewState extends State<WhatYourGoalView> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              const SizedBox(height: 12),
+              const SizedBox(height: 16),
               Text(
-                "What is your goal ?",
+                context.localize(_title),
                 textAlign: TextAlign.center,
                 style: TextStyle(
                   color: TColor.black,
-                  fontSize: 20,
+                  fontSize: 22,
                   fontWeight: FontWeight.w700,
                 ),
               ),
               const SizedBox(height: 6),
               Text(
-                "It will help us to choose a best program for you",
+                context.localize(_subtitle),
                 textAlign: TextAlign.center,
                 style: TextStyle(color: TColor.gray, fontSize: 12),
               ),
-
               const SizedBox(height: 32),
-
-              // Carousel di tengah
               Expanded(
                 child: CarouselSlider.builder(
-                  carouselController: _controller,
-                  itemCount: goalArr.length,
+                  itemCount: _goals.length,
                   itemBuilder: (context, index, realIdx) {
-                    final gObj = goalArr[index];
+                    final goal = _goals[index];
                     return Container(
                       decoration: BoxDecoration(
                         gradient: LinearGradient(
@@ -94,13 +118,14 @@ class _WhatYourGoalViewState extends State<WhatYourGoalView> {
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: [
                           Image.asset(
-                            gObj["image"]!,
+                            goal.image,
                             width: media.width * 0.5,
                             fit: BoxFit.contain,
                           ),
                           const SizedBox(height: 24),
                           Text(
-                            gObj["title"]!,
+                            context.localize(goal.title),
+                            textAlign: TextAlign.center,
                             style: TextStyle(
                               color: TColor.white,
                               fontSize: 16,
@@ -111,7 +136,7 @@ class _WhatYourGoalViewState extends State<WhatYourGoalView> {
                           Container(width: 40, height: 1, color: TColor.white),
                           const SizedBox(height: 12),
                           Text(
-                            gObj["subtitle"]!,
+                            context.localize(goal.subtitle),
                             textAlign: TextAlign.center,
                             style: TextStyle(color: TColor.white, fontSize: 12),
                           ),
@@ -126,11 +151,9 @@ class _WhatYourGoalViewState extends State<WhatYourGoalView> {
                   ),
                 ),
               ),
-
               const SizedBox(height: 24),
-
               RoundButton(
-                title: "Confirm",
+                title: context.localize(_confirmText),
                 onPressed: () {
                   context.push(AppRoute.welcome);
                 },
@@ -142,4 +165,16 @@ class _WhatYourGoalViewState extends State<WhatYourGoalView> {
       ),
     );
   }
+}
+
+class _GoalCardData {
+  const _GoalCardData({
+    required this.image,
+    required this.title,
+    required this.subtitle,
+  });
+
+  final String image;
+  final LocalizedText title;
+  final LocalizedText subtitle;
 }

--- a/lib/view/on_boarding/on_boarding_view.dart
+++ b/lib/view/on_boarding/on_boarding_view.dart
@@ -1,6 +1,8 @@
 import 'package:aigymbuddy/common/app_router.dart';
 import 'package:aigymbuddy/common/color_extension.dart';
 import 'package:aigymbuddy/common/localization/app_language.dart';
+import 'package:aigymbuddy/common/localization/app_language_scope.dart';
+import 'package:aigymbuddy/common_widget/app_language_toggle.dart';
 import 'package:aigymbuddy/common_widget/on_boarding_page.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
@@ -12,37 +14,9 @@ class OnBoardingView extends StatefulWidget {
   State<OnBoardingView> createState() => _OnBoardingViewState();
 }
 
-class _LanguageToggleButton extends StatelessWidget {
-  const _LanguageToggleButton({
-    required this.language,
-    required this.onPressed,
-  });
-
-  final AppLanguage language;
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return OutlinedButton.icon(
-      style: OutlinedButton.styleFrom(
-        foregroundColor: TColor.primaryColor1,
-        side: BorderSide(color: TColor.primaryColor1),
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      ),
-      onPressed: onPressed,
-      icon: const Icon(Icons.language, size: 18),
-      label: Text(
-        language.buttonLabel,
-        style: const TextStyle(fontWeight: FontWeight.w600),
-      ),
-    );
-  }
-}
-
 class _OnBoardingViewState extends State<OnBoardingView> {
   final PageController _pageController = PageController();
   int _currentPageIndex = 0;
-  AppLanguage _language = AppLanguage.english;
 
   late final List<OnBoardingContent> _pages = [
     OnBoardingContent(
@@ -172,16 +146,11 @@ class _OnBoardingViewState extends State<OnBoardingView> {
     });
   }
 
-  void _updateLanguage(AppLanguage language) {
-    if (language == _language) return;
-
-    setState(() {
-      _language = language;
-    });
-  }
-
   @override
   Widget build(BuildContext context) {
+    final languageController = AppLanguageScope.of(context);
+    final language = context.appLanguage;
+
     return Scaffold(
       backgroundColor: TColor.white,
       body: Stack(
@@ -194,7 +163,7 @@ class _OnBoardingViewState extends State<OnBoardingView> {
             itemBuilder: (context, index) {
               return OnBoardingPage(
                 content: _pages[index],
-                language: _language,
+                language: language,
                 onNext: _handleNext,
               );
             },
@@ -210,79 +179,13 @@ class _OnBoardingViewState extends State<OnBoardingView> {
             top: 16,
             right: 16,
             child: SafeArea(
-              child: _OnboardingLanguageMenu(
-                selectedLanguage: _language,
-                onLanguageSelected: _updateLanguage,
+              child: AppLanguageToggle(
+                selectedLanguage: language,
+                onSelected: languageController.select,
               ),
             ),
           ),
         ],
-      ),
-    );
-  }
-}
-
-class _OnboardingLanguageMenu extends StatelessWidget {
-  const _OnboardingLanguageMenu({
-    required this.selectedLanguage,
-    required this.onLanguageSelected,
-  });
-
-  final AppLanguage selectedLanguage;
-  final ValueChanged<AppLanguage> onLanguageSelected;
-
-  @override
-  Widget build(BuildContext context) {
-    return PopupMenuButton<AppLanguage>(
-      tooltip: 'Select language',
-      initialValue: selectedLanguage,
-      onSelected: onLanguageSelected,
-      itemBuilder: (context) {
-        return AppLanguage.values
-            .map(
-              (language) => PopupMenuItem<AppLanguage>(
-                value: language,
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    const Icon(Icons.translate, size: 18),
-                    const SizedBox(width: 8),
-                    Text(language.displayName),
-                    const Spacer(),
-                    if (language == selectedLanguage)
-                      Icon(Icons.check, color: TColor.primaryColor1, size: 18),
-                  ],
-                ),
-              ),
-            )
-            .toList();
-      },
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          border: Border.all(color: TColor.primaryColor1),
-          borderRadius: BorderRadius.circular(28),
-        ),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const Icon(
-                Icons.translate,
-                size: 18,
-                color: TColor.primaryColor1,
-              ),
-              const SizedBox(width: 8),
-              Text(
-                selectedLanguage.buttonLabel,
-                style: const TextStyle(
-                  color: TColor.primaryColor1,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ],
-          ),
-        ),
       ),
     );
   }
@@ -352,201 +255,6 @@ class _OnboardingProgressButton extends StatelessWidget {
               ),
             ),
           ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildProgressButton(int totalPages) {
-    final content = _pages[_currentPageIndex];
-    if (content.isWelcome) {
-      return const SizedBox.shrink();
-    }
-
-    final progress = (_currentPageIndex + 1) / totalPages;
-    final gradient = content.gradientColors ?? TColor.primaryG;
-
-    return Padding(
-      padding: const EdgeInsets.only(right: 24, bottom: 40),
-      child: SizedBox(
-        width: 88,
-        height: 88,
-        child: Stack(
-          alignment: Alignment.center,
-          children: [
-            SizedBox(
-              width: 72,
-              height: 72,
-              child: CircularProgressIndicator(
-                color: TColor.primaryColor1,
-                value: progress,
-                strokeWidth: 3,
-                backgroundColor: TColor.lightGray,
-              ),
-            ),
-            DecoratedBox(
-              decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  colors: gradient,
-                  begin: Alignment.topLeft,
-                  end: Alignment.bottomRight,
-                ),
-                shape: BoxShape.circle,
-                boxShadow: [
-                  BoxShadow(
-                    color: gradient.last.withValues(alpha: 0.3),
-                    blurRadius: 10,
-                    offset: const Offset(0, 6),
-                  ),
-                ],
-              ),
-              child: SizedBox(
-                width: 56,
-                height: 56,
-                child: IconButton(
-                  onPressed: _handleNext,
-                  icon: Icon(
-                    _currentPageIndex == totalPages - 1
-                        ? Icons.check_rounded
-                        : Icons.arrow_forward_rounded,
-                    color: TColor.white,
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _LanguageMenuButton extends StatelessWidget {
-  const _LanguageMenuButton({
-    required this.selectedLanguage,
-    required this.onLanguageSelected,
-  });
-
-  final AppLanguage selectedLanguage;
-  final ValueChanged<AppLanguage> onLanguageSelected;
-
-  @override
-  Widget build(BuildContext context) {
-    return PopupMenuButton<AppLanguage>(
-      tooltip: 'Select language',
-      initialValue: selectedLanguage,
-      onSelected: onLanguageSelected,
-      itemBuilder: (context) {
-        return AppLanguage.values
-            .map(
-              (language) => PopupMenuItem<AppLanguage>(
-                value: language,
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    const Icon(Icons.translate, size: 18),
-                    const SizedBox(width: 8),
-                    Text(language.displayName),
-                    const Spacer(),
-                    if (language == selectedLanguage)
-                      Icon(Icons.check, color: TColor.primaryColor1, size: 18),
-                  ],
-                ),
-              ),
-            )
-            .toList();
-      },
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          border: Border.all(color: TColor.primaryColor1),
-          borderRadius: BorderRadius.circular(28),
-        ),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const Icon(
-                Icons.translate,
-                size: 18,
-                color: TColor.primaryColor1,
-              ),
-              const SizedBox(width: 8),
-              Text(
-                selectedLanguage.buttonLabel,
-                style: const TextStyle(
-                  color: TColor.primaryColor1,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _LanguageMenuButton extends StatelessWidget {
-  const _LanguageMenuButton({
-    required this.selectedLanguage,
-    required this.onLanguageSelected,
-  });
-
-  final AppLanguage selectedLanguage;
-  final ValueChanged<AppLanguage> onLanguageSelected;
-
-  @override
-  Widget build(BuildContext context) {
-    return PopupMenuButton<AppLanguage>(
-      tooltip: 'Select language',
-      initialValue: selectedLanguage,
-      onSelected: onLanguageSelected,
-      itemBuilder: (context) {
-        return AppLanguage.values
-            .map(
-              (language) => PopupMenuItem<AppLanguage>(
-                value: language,
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    const Icon(Icons.translate, size: 18),
-                    const SizedBox(width: 8),
-                    Text(language.displayName),
-                    const Spacer(),
-                    if (language == selectedLanguage)
-                      Icon(Icons.check, color: TColor.primaryColor1, size: 18),
-                  ],
-                ),
-              ),
-            )
-            .toList();
-      },
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          border: Border.all(color: TColor.primaryColor1),
-          borderRadius: BorderRadius.circular(28),
-        ),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const Icon(
-                Icons.translate,
-                size: 18,
-                color: TColor.primaryColor1,
-              ),
-              const SizedBox(width: 8),
-              Text(
-                selectedLanguage.shortLabel,
-                style: const TextStyle(
-                  color: TColor.primaryColor1,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ],
-          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- rebuild the complete profile screen with localized strings, reusable helpers, and cleaned controllers
- centralize the gender dropdown and measurement rows so they reuse shared builders and resolve text through the shared language scope
- remove the stale language toggle import from the welcome view
- extract the complete profile header into a dedicated widget so its localized copy is resolved once and reused across the layout
- center the sign-up form vertically so the inputs and actions sit comfortably in the middle of the screen

## Testing
- Not run (Flutter SDK unavailable in the environment)

------
https://chatgpt.com/codex/tasks/task_e_68e27e0887208333882802d7d1b46328