### PR TITLE
Enhance workout tracker interactions

### DIFF
--- a/lib/common_widget/round_textfield.dart
+++ b/lib/common_widget/round_textfield.dart
@@ -1,38 +1,71 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import '../common/color_extension.dart';
 
 class RoundTextField extends StatelessWidget {
-  final TextEditingController? controller;
-  final TextInputType? keyboardType;
-  final String hitText;
-  final String icon;
-  final Widget? rigtIcon;
-  final bool obscureText;
-  final EdgeInsets? margin;
   const RoundTextField({
     super.key,
-    required this.hitText,
+    required this.hintText,
     required this.icon,
     this.controller,
     this.margin,
     this.keyboardType,
     this.obscureText = false,
-    this.rigtIcon,
+    this.rightIcon,
+    this.inputFormatters,
+    this.textInputAction,
+    this.validator,
+    this.onChanged,
+    this.autovalidateMode,
+    this.focusNode,
+    this.onFieldSubmitted,
+    this.enabled = true,
+    this.textCapitalization = TextCapitalization.none,
   });
+
+  final TextEditingController? controller;
+  final TextInputType? keyboardType;
+  final String hintText;
+  final String icon;
+  final Widget? rightIcon;
+  final bool obscureText;
+  final EdgeInsets? margin;
+  final List<TextInputFormatter>? inputFormatters;
+  final TextInputAction? textInputAction;
+  final FormFieldValidator<String>? validator;
+  final ValueChanged<String>? onChanged;
+  final AutovalidateMode? autovalidateMode;
+  final FocusNode? focusNode;
+  final ValueChanged<String>? onFieldSubmitted;
+  final bool enabled;
+  final TextCapitalization textCapitalization;
 
   @override
   Widget build(BuildContext context) {
+    final backgroundColor = enabled
+        ? TColor.lightGray
+        : TColor.lightGray.withValues(alpha: 0.6);
+
     return Container(
       margin: margin,
       decoration: BoxDecoration(
-        color: TColor.lightGray,
+        color: backgroundColor,
         borderRadius: BorderRadius.circular(15),
       ),
-      child: TextField(
+      child: TextFormField(
         controller: controller,
+        focusNode: focusNode,
         keyboardType: keyboardType,
         obscureText: obscureText,
+        inputFormatters: inputFormatters,
+        textInputAction: textInputAction,
+        textCapitalization: textCapitalization,
+        validator: validator,
+        onChanged: onChanged,
+        autovalidateMode: autovalidateMode,
+        onFieldSubmitted: onFieldSubmitted,
+        enabled: enabled,
         decoration: InputDecoration(
           contentPadding: const EdgeInsets.symmetric(
             vertical: 15,
@@ -40,8 +73,10 @@ class RoundTextField extends StatelessWidget {
           ),
           enabledBorder: InputBorder.none,
           focusedBorder: InputBorder.none,
-          hintText: hitText,
-          suffixIcon: rigtIcon,
+          errorBorder: InputBorder.none,
+          focusedErrorBorder: InputBorder.none,
+          hintText: hintText,
+          suffixIcon: rightIcon,
           prefixIcon: Container(
             alignment: Alignment.center,
             width: 20,
@@ -53,6 +88,11 @@ class RoundTextField extends StatelessWidget {
               fit: BoxFit.contain,
               color: TColor.gray,
             ),
+          ),
+          errorStyle: TextStyle(
+            color: Theme.of(context).colorScheme.error,
+            fontSize: 12,
+            fontWeight: FontWeight.w500,
           ),
           hintStyle: TextStyle(color: TColor.gray, fontSize: 12),
         ),

--- a/lib/view/login/complete_profile_view.dart
+++ b/lib/view/login/complete_profile_view.dart
@@ -5,6 +5,7 @@ import 'package:aigymbuddy/common/localization/app_language_scope.dart';
 import 'package:aigymbuddy/common_widget/round_button.dart';
 import 'package:aigymbuddy/common_widget/round_textfield.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 
 class CompleteProfileView extends StatefulWidget {
@@ -18,9 +19,24 @@ class _CompleteProfileViewState extends State<CompleteProfileView> {
   final TextEditingController _weightController = TextEditingController();
   final TextEditingController _heightController = TextEditingController();
   _Gender? _selectedGender;
+  String? _genderError;
+  String? _dobError;
+  String? _weightError;
+  String? _heightError;
   static const _decimalKeyboard = TextInputType.numberWithOptions(
     decimal: true,
   );
+  static const double _minWeightKg = 20;
+  static const double _maxWeightKg = 500;
+  static const double _minHeightCm = 50;
+  static const double _maxHeightCm = 300;
+  static const int _minAgeYears = 13;
+  static final List<TextInputFormatter> _numericInputFormatters = [
+    FilteringTextInputFormatter.allow(
+      RegExp(r'^[0-9]{0,3}(?:\.[0-9]{0,2})?$'),
+    ),
+    LengthLimitingTextInputFormatter(6),
+  ];
   static const _title = LocalizedText(
     english: "Let’s complete your profile",
     indonesian: 'Lengkapi profil Anda',
@@ -53,6 +69,46 @@ class _CompleteProfileViewState extends State<CompleteProfileView> {
     english: 'Next >',
     indonesian: 'Berikutnya >',
   );
+  static const _genderRequiredError = LocalizedText(
+    english: 'Please select your gender.',
+    indonesian: 'Silakan pilih jenis kelamin Anda.',
+  );
+  static const _dobRequiredError = LocalizedText(
+    english: 'Please select your date of birth.',
+    indonesian: 'Silakan pilih tanggal lahir Anda.',
+  );
+  static const _dobInvalidError = LocalizedText(
+    english: 'Please choose a valid date of birth.',
+    indonesian: 'Silakan pilih tanggal lahir yang valid.',
+  );
+  static const _dobAgeRestrictionError = LocalizedText(
+    english: 'You must be at least 13 years old.',
+    indonesian: 'Anda harus berusia minimal 13 tahun.',
+  );
+  static const _measurementRequiredError = LocalizedText(
+    english: 'This field is required.',
+    indonesian: 'Kolom ini wajib diisi.',
+  );
+  static const _measurementInvalidError = LocalizedText(
+    english: 'Enter a valid number.',
+    indonesian: 'Masukkan angka yang valid.',
+  );
+  static const _weightOutOfRangeError = LocalizedText(
+    english: 'Weight must be between 20 and 500 KG.',
+    indonesian: 'Berat badan harus antara 20 dan 500 KG.',
+  );
+  static const _heightOutOfRangeError = LocalizedText(
+    english: 'Height must be between 50 and 300 CM.',
+    indonesian: 'Tinggi badan harus antara 50 dan 300 CM.',
+  );
+
+  @override
+  void initState() {
+    super.initState();
+    _weightController.addListener(_handleWeightChanged);
+    _heightController.addListener(_handleHeightChanged);
+  }
+
   @override
   void dispose() {
     _dobController.dispose();
@@ -83,18 +139,115 @@ class _CompleteProfileViewState extends State<CompleteProfileView> {
       },
     );
     if (picked != null) {
-      _dobController.text =
-          '${picked.year.toString().padLeft(4, '0')}-'
-          '${picked.month.toString().padLeft(2, '0')}-'
-          '${picked.day.toString().padLeft(2, '0')}';
-      setState(() {});
+      setState(() {
+        _dobController.text =
+            '${picked.year.toString().padLeft(4, '0')}-'
+            '${picked.month.toString().padLeft(2, '0')}-'
+            '${picked.day.toString().padLeft(2, '0')}';
+        _dobError = null;
+      });
     }
   }
 
   void _onGenderChanged(_Gender? gender) {
     setState(() {
       _selectedGender = gender;
+      _genderError = null;
     });
+  }
+
+  void _handleWeightChanged() {
+    if (_weightError != null) {
+      setState(() {
+        _weightError = _validateWeight(context, _weightController.text);
+      });
+    }
+  }
+
+  void _handleHeightChanged() {
+    if (_heightError != null) {
+      setState(() {
+        _heightError = _validateHeight(context, _heightController.text);
+      });
+    }
+  }
+
+  void _onNextPressed() {
+    final genderError =
+        _selectedGender == null ? context.localize(_genderRequiredError) : null;
+    final dobError = _validateDob(context, _dobController.text);
+    final weightError = _validateWeight(context, _weightController.text);
+    final heightError = _validateHeight(context, _heightController.text);
+    setState(() {
+      _genderError = genderError;
+      _dobError = dobError;
+      _weightError = weightError;
+      _heightError = heightError;
+    });
+    if ([genderError, dobError, weightError, heightError].every((e) => e == null)) {
+      context.push(AppRoute.goal);
+    }
+  }
+
+  String? _validateDob(BuildContext context, String raw) {
+    final text = raw.trim();
+    if (text.isEmpty) {
+      return context.localize(_dobRequiredError);
+    }
+    final parsed = DateTime.tryParse(text);
+    if (parsed == null) {
+      return context.localize(_dobInvalidError);
+    }
+    final now = DateTime.now();
+    if (parsed.isAfter(now)) {
+      return context.localize(_dobInvalidError);
+    }
+    final ageThreshold = DateTime(now.year - _minAgeYears, now.month, now.day);
+    if (parsed.isAfter(ageThreshold)) {
+      return context.localize(_dobAgeRestrictionError);
+    }
+    return null;
+  }
+
+  String? _validateWeight(BuildContext context, String raw) {
+    return _validateMeasurement(
+      context: context,
+      raw: raw,
+      min: _minWeightKg,
+      max: _maxWeightKg,
+      outOfRangeError: _weightOutOfRangeError,
+    );
+  }
+
+  String? _validateHeight(BuildContext context, String raw) {
+    return _validateMeasurement(
+      context: context,
+      raw: raw,
+      min: _minHeightCm,
+      max: _maxHeightCm,
+      outOfRangeError: _heightOutOfRangeError,
+    );
+  }
+
+  String? _validateMeasurement({
+    required BuildContext context,
+    required String raw,
+    required double min,
+    required double max,
+    required LocalizedText outOfRangeError,
+  }) {
+    final text = raw.trim();
+    if (text.isEmpty) {
+      return context.localize(_measurementRequiredError);
+    }
+    final value = double.tryParse(text);
+    if (value == null) {
+      return context.localize(_measurementInvalidError);
+    }
+    if (value < min || value > max) {
+      return context.localize(outOfRangeError);
+    }
+    return null;
   }
 
   @override
@@ -131,17 +284,7 @@ class _CompleteProfileViewState extends State<CompleteProfileView> {
                       const SizedBox(height: 24),
                       _buildGenderField(context),
                       const SizedBox(height: 16),
-                      GestureDetector(
-                        onTap: _pickDob,
-                        behavior: HitTestBehavior.opaque,
-                        child: AbsorbPointer(
-                          child: RoundTextField(
-                            controller: _dobController,
-                            hitText: context.localize(_dobHint),
-                            icon: 'assets/img/date.png',
-                          ),
-                        ),
-                      ),
+                      _buildDobField(context),
                       const SizedBox(height: 16),
                       _buildMeasurementField(
                         context,
@@ -149,6 +292,7 @@ class _CompleteProfileViewState extends State<CompleteProfileView> {
                         hint: _weightHint,
                         iconAsset: 'assets/img/weight.png',
                         unit: 'KG',
+                        errorText: _weightError,
                       ),
                       const SizedBox(height: 16),
                       _buildMeasurementField(
@@ -157,13 +301,12 @@ class _CompleteProfileViewState extends State<CompleteProfileView> {
                         hint: _heightHint,
                         iconAsset: 'assets/img/hight.png',
                         unit: 'CM',
+                        errorText: _heightError,
                       ),
                       const SizedBox(height: 28),
                       RoundButton(
                         title: localize(_nextText),
-                        onPressed: () {
-                          context.push(AppRoute.goal);
-                        },
+                        onPressed: _onNextPressed,
                       ),
                     ],
                   ),
@@ -177,52 +320,84 @@ class _CompleteProfileViewState extends State<CompleteProfileView> {
   }
 
   Widget _buildGenderField(BuildContext context) {
-    return Container(
-      height: 50,
-      padding: const EdgeInsets.symmetric(horizontal: 12),
-      decoration: BoxDecoration(
-        color: TColor.lightGray,
-        borderRadius: BorderRadius.circular(15),
-      ),
-      child: Row(
-        children: [
-          Image.asset(
-            'assets/img/gender.png',
-            width: 20,
-            height: 20,
-            color: TColor.gray,
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          height: 50,
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          decoration: BoxDecoration(
+            color: TColor.lightGray,
+            borderRadius: BorderRadius.circular(15),
           ),
-          const SizedBox(width: 12),
-          Expanded(
-            child: DropdownButtonHideUnderline(
-              child: DropdownButton<_Gender>(
-                isExpanded: true,
-                value: _selectedGender,
-                hint: Text(
-                  context.localize(_genderHint),
-                  style: TextStyle(color: TColor.gray, fontSize: 12),
-                ),
-                icon: Icon(
-                  Icons.keyboard_arrow_down_rounded,
-                  color: TColor.gray,
-                ),
-                items: _Gender.values
-                    .map(
-                      (gender) => DropdownMenuItem<_Gender>(
-                        value: gender,
-                        child: Text(
-                          context.localize(gender.label),
-                          style: TextStyle(color: TColor.gray, fontSize: 14),
-                        ),
-                      ),
-                    )
-                    .toList(),
-                onChanged: _onGenderChanged,
+          child: Row(
+            children: [
+              Image.asset(
+                'assets/img/gender.png',
+                width: 20,
+                height: 20,
+                color: TColor.gray,
               ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: DropdownButtonHideUnderline(
+                  child: DropdownButton<_Gender>(
+                    isExpanded: true,
+                    value: _selectedGender,
+                    hint: Text(
+                      context.localize(_genderHint),
+                      style: TextStyle(color: TColor.gray, fontSize: 12),
+                    ),
+                    icon: Icon(
+                      Icons.keyboard_arrow_down_rounded,
+                      color: TColor.gray,
+                    ),
+                    items: _Gender.values
+                        .map(
+                          (gender) => DropdownMenuItem<_Gender>(
+                            value: gender,
+                            child: Text(
+                              context.localize(gender.label),
+                              style: TextStyle(color: TColor.gray, fontSize: 14),
+                            ),
+                          ),
+                        )
+                        .toList(),
+                    onChanged: _onGenderChanged,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        if (_genderError != null) ...[
+          const SizedBox(height: 6),
+          _ErrorText(text: _genderError!),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildDobField(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        GestureDetector(
+          onTap: _pickDob,
+          behavior: HitTestBehavior.opaque,
+          child: AbsorbPointer(
+            child: RoundTextField(
+              controller: _dobController,
+              hintText: context.localize(_dobHint),
+              icon: 'assets/img/date.png',
             ),
           ),
+        ),
+        if (_dobError != null) ...[
+          const SizedBox(height: 6),
+          _ErrorText(text: _dobError!),
         ],
-      ),
+      ],
     );
   }
 
@@ -232,20 +407,49 @@ class _CompleteProfileViewState extends State<CompleteProfileView> {
     required LocalizedText hint,
     required String iconAsset,
     required String unit,
+    String? errorText,
   }) {
-    return Row(
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Expanded(
-          child: RoundTextField(
-            controller: controller,
-            hitText: context.localize(hint),
-            icon: iconAsset,
-            keyboardType: _decimalKeyboard,
-          ),
+        Row(
+          children: [
+            Expanded(
+              child: RoundTextField(
+                controller: controller,
+                hintText: context.localize(hint),
+                icon: iconAsset,
+                keyboardType: _decimalKeyboard,
+                inputFormatters: _numericInputFormatters,
+              ),
+            ),
+            const SizedBox(width: 8),
+            _UnitTag(text: unit),
+          ],
         ),
-        const SizedBox(width: 8),
-        _UnitTag(text: unit),
+        if (errorText != null) ...[
+          const SizedBox(height: 6),
+          _ErrorText(text: errorText),
+        ],
       ],
+    );
+  }
+}
+
+class _ErrorText extends StatelessWidget {
+  const _ErrorText({required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      style: TextStyle(
+        color: Theme.of(context).colorScheme.error,
+        fontSize: 12,
+        fontWeight: FontWeight.w500,
+      ),
     );
   }
 }

--- a/lib/view/login/login_view.dart
+++ b/lib/view/login/login_view.dart
@@ -16,7 +16,15 @@ class LoginView extends StatefulWidget {
 }
 
 class _LoginViewState extends State<LoginView> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _emailFocusNode = FocusNode();
+  final _passwordFocusNode = FocusNode();
+
   bool _isPasswordVisible = false;
+  bool _isLoginEnabled = false;
+  bool _autoValidate = false;
 
   static const _socialProviders = [
     'assets/img/google.png',
@@ -57,6 +65,37 @@ class _LoginViewState extends State<LoginView> {
     indonesian: 'Daftar',
   );
 
+  static final RegExp _emailRegExp = RegExp(
+    '^[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}$',
+    caseSensitive: false,
+  );
+
+  static const _emailRequiredError = LocalizedText(
+    english: 'Email is required',
+    indonesian: 'Email wajib diisi',
+  );
+  static const _emailInvalidError = LocalizedText(
+    english: 'Enter a valid email address',
+    indonesian: 'Masukkan alamat email yang valid',
+  );
+  static const _passwordRequiredError = LocalizedText(
+    english: 'Password is required',
+    indonesian: 'Kata sandi wajib diisi',
+  );
+  static const _passwordLengthError = LocalizedText(
+    english: 'Password must be at least 8 characters',
+    indonesian: 'Kata sandi minimal 8 karakter',
+  );
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    _emailFocusNode.dispose();
+    _passwordFocusNode.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -84,34 +123,40 @@ class _LoginViewState extends State<LoginView> {
   }
 
   Widget _buildContent(BuildContext context, double minHeight) {
+    final autovalidateMode =
+        _autoValidate ? AutovalidateMode.onUserInteraction : AutovalidateMode.disabled;
+
     return ConstrainedBox(
       constraints: BoxConstraints(minHeight: minHeight),
-      child: Column(
-        mainAxisSize: MainAxisSize.max,
-        mainAxisAlignment: MainAxisAlignment.center,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          _buildHeader(context),
-          const SizedBox(height: 36),
-          _buildEmailField(context),
-          const SizedBox(height: 20),
-          _buildPasswordField(context),
-          const SizedBox(height: 16),
-          _buildForgotPasswordButton(context),
-          const SizedBox(height: 28),
-          RoundButton(
-            title: context.localize(_loginButtonText),
-            onPressed: () {
-              context.push(AppRoute.completeProfile);
-            },
-          ),
-          const SizedBox(height: 28),
-          _buildDivider(context),
-          const SizedBox(height: 24),
-          _buildSocialRow(),
-          const SizedBox(height: 28),
-          _buildSignUpPrompt(context),
-        ],
+      child: Form(
+        key: _formKey,
+        autovalidateMode: autovalidateMode,
+        child: Column(
+          mainAxisSize: MainAxisSize.max,
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _buildHeader(context),
+            const SizedBox(height: 36),
+            _buildEmailField(context, autovalidateMode),
+            const SizedBox(height: 20),
+            _buildPasswordField(context, autovalidateMode),
+            const SizedBox(height: 16),
+            _buildForgotPasswordButton(context),
+            const SizedBox(height: 28),
+            RoundButton(
+              title: context.localize(_loginButtonText),
+              onPressed: _onLoginPressed,
+              isEnabled: _isLoginEnabled,
+            ),
+            const SizedBox(height: 28),
+            _buildDivider(context),
+            const SizedBox(height: 24),
+            _buildSocialRow(),
+            const SizedBox(height: 28),
+            _buildSignUpPrompt(context),
+          ],
+        ),
       ),
     );
   }
@@ -139,20 +184,34 @@ class _LoginViewState extends State<LoginView> {
     );
   }
 
-  Widget _buildEmailField(BuildContext context) {
+  Widget _buildEmailField(BuildContext context, AutovalidateMode autovalidateMode) {
     return RoundTextField(
-      hitText: context.localize(_emailHint),
+      controller: _emailController,
+      focusNode: _emailFocusNode,
+      hintText: context.localize(_emailHint),
       icon: 'assets/img/email.png',
       keyboardType: TextInputType.emailAddress,
+      textInputAction: TextInputAction.next,
+      autovalidateMode: autovalidateMode,
+      validator: _validateEmail,
+      onChanged: _onFieldChanged,
+      onFieldSubmitted: (_) => _passwordFocusNode.requestFocus(),
     );
   }
 
-  Widget _buildPasswordField(BuildContext context) {
+  Widget _buildPasswordField(BuildContext context, AutovalidateMode autovalidateMode) {
     return RoundTextField(
-      hitText: context.localize(_passwordHint),
+      controller: _passwordController,
+      focusNode: _passwordFocusNode,
+      hintText: context.localize(_passwordHint),
       icon: 'assets/img/lock.png',
       obscureText: !_isPasswordVisible,
-      rigtIcon: IconButton(
+      textInputAction: TextInputAction.done,
+      autovalidateMode: autovalidateMode,
+      validator: _validatePassword,
+      onChanged: _onFieldChanged,
+      onFieldSubmitted: (_) => _onLoginPressed(),
+      rightIcon: IconButton(
         padding: EdgeInsets.zero,
         constraints: const BoxConstraints(),
         onPressed: () {
@@ -256,5 +315,59 @@ class _LoginViewState extends State<LoginView> {
         ],
       ),
     );
+  }
+
+  void _onFieldChanged(String _) {
+    final isValid = _canSubmit();
+    if (isValid != _isLoginEnabled) {
+      setState(() {
+        _isLoginEnabled = isValid;
+      });
+    }
+  }
+
+  void _onLoginPressed() {
+    final form = _formKey.currentState;
+    if (form == null) {
+      return;
+    }
+
+    setState(() {
+      _autoValidate = true;
+    });
+
+    if (!form.validate()) {
+      _onFieldChanged('');
+      return;
+    }
+
+    context.push(AppRoute.completeProfile);
+  }
+
+  String? _validateEmail(String? value) {
+    final text = value?.trim() ?? '';
+    if (text.isEmpty) {
+      return context.localize(_emailRequiredError);
+    }
+    if (!_emailRegExp.hasMatch(text)) {
+      return context.localize(_emailInvalidError);
+    }
+    return null;
+  }
+
+  String? _validatePassword(String? value) {
+    final text = value ?? '';
+    if (text.isEmpty) {
+      return context.localize(_passwordRequiredError);
+    }
+    if (text.length < 8) {
+      return context.localize(_passwordLengthError);
+    }
+    return null;
+  }
+
+  bool _canSubmit() {
+    return _validateEmail(_emailController.text) == null &&
+        _validatePassword(_passwordController.text) == null;
   }
 }

--- a/lib/view/login/signup_view.dart
+++ b/lib/view/login/signup_view.dart
@@ -16,8 +16,22 @@ class SignUpView extends StatefulWidget {
 }
 
 class _SignUpViewState extends State<SignUpView> {
+  final _formKey = GlobalKey<FormState>();
+  final _firstNameController = TextEditingController();
+  final _lastNameController = TextEditingController();
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+
+  final _firstNameFocusNode = FocusNode();
+  final _lastNameFocusNode = FocusNode();
+  final _emailFocusNode = FocusNode();
+  final _passwordFocusNode = FocusNode();
+
   bool _isTermsAccepted = false;
   bool _isPasswordVisible = false;
+  bool _isRegisterEnabled = false;
+  bool _autoValidate = false;
+  bool _showTermsError = false;
 
   static const _greetingText = LocalizedText(
     english: 'Hey there,',
@@ -62,6 +76,53 @@ class _SignUpViewState extends State<SignUpView> {
     indonesian: 'Masuk',
   );
 
+  static const _firstNameRequiredError = LocalizedText(
+    english: 'First name is required',
+    indonesian: 'Nama depan wajib diisi',
+  );
+  static const _lastNameRequiredError = LocalizedText(
+    english: 'Last name is required',
+    indonesian: 'Nama belakang wajib diisi',
+  );
+  static const _emailRequiredError = LocalizedText(
+    english: 'Email is required',
+    indonesian: 'Email wajib diisi',
+  );
+  static const _emailInvalidError = LocalizedText(
+    english: 'Enter a valid email address',
+    indonesian: 'Masukkan alamat email yang valid',
+  );
+  static const _passwordRequiredError = LocalizedText(
+    english: 'Password is required',
+    indonesian: 'Kata sandi wajib diisi',
+  );
+  static const _passwordLengthError = LocalizedText(
+    english: 'Password must be at least 8 characters',
+    indonesian: 'Kata sandi minimal 8 karakter',
+  );
+  static const _termsRequiredError = LocalizedText(
+    english: 'Please accept the terms to continue',
+    indonesian: 'Silakan setujui syarat dan ketentuan terlebih dahulu',
+  );
+
+  static final RegExp _emailRegExp = RegExp(
+    '^[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}$',
+    caseSensitive: false,
+  );
+
+  @override
+  void dispose() {
+    _firstNameController.dispose();
+    _lastNameController.dispose();
+    _emailController.dispose();
+    _passwordController.dispose();
+    _firstNameFocusNode.dispose();
+    _lastNameFocusNode.dispose();
+    _emailFocusNode.dispose();
+    _passwordFocusNode.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -77,162 +138,7 @@ class _SignUpViewState extends State<SignUpView> {
                     maxWidth: 420,
                     minHeight: constraints.maxHeight,
                   ),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      const SizedBox(height: 24),
-                      Text(
-                        context.localize(_greetingText),
-                        textAlign: TextAlign.center,
-                        style: TextStyle(color: TColor.gray, fontSize: 16),
-                      ),
-                      const SizedBox(height: 4),
-                      Text(
-                        context.localize(_createAccountText),
-                        textAlign: TextAlign.center,
-                        style: TextStyle(
-                          color: TColor.black,
-                          fontSize: 24,
-                          fontWeight: FontWeight.w700,
-                        ),
-                      ),
-                      const SizedBox(height: 28),
-                      RoundTextField(
-                        hitText: context.localize(_firstNameHint),
-                        icon: 'assets/img/user_text.png',
-                      ),
-                      const SizedBox(height: 16),
-                      RoundTextField(
-                        hitText: context.localize(_lastNameHint),
-                        icon: 'assets/img/user_text.png',
-                      ),
-                      const SizedBox(height: 16),
-                      RoundTextField(
-                        hitText: context.localize(_emailHint),
-                        icon: 'assets/img/email.png',
-                        keyboardType: TextInputType.emailAddress,
-                      ),
-                      const SizedBox(height: 16),
-                      RoundTextField(
-                        hitText: context.localize(_passwordHint),
-                        icon: 'assets/img/lock.png',
-                        obscureText: !_isPasswordVisible,
-                        rigtIcon: IconButton(
-                          padding: EdgeInsets.zero,
-                          constraints: const BoxConstraints(),
-                          onPressed: () {
-                            setState(() {
-                              _isPasswordVisible = !_isPasswordVisible;
-                            });
-                          },
-                          icon: Image.asset(
-                            _isPasswordVisible
-                                ? 'assets/img/hide_password.png'
-                                : 'assets/img/show_password.png',
-                            width: 20,
-                            height: 20,
-                            color: TColor.gray,
-                          ),
-                        ),
-                      ),
-                      const SizedBox(height: 12),
-                      Row(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Checkbox(
-                            value: _isTermsAccepted,
-                            onChanged: (value) {
-                              setState(() {
-                                _isTermsAccepted = value ?? false;
-                              });
-                            },
-                            visualDensity: VisualDensity.compact,
-                            materialTapTargetSize:
-                                MaterialTapTargetSize.shrinkWrap,
-                          ),
-                          const SizedBox(width: 4),
-                          Expanded(
-                            child: Text(
-                              context.localize(_termsText),
-                              style: TextStyle(
-                                color: TColor.gray,
-                                fontSize: 12,
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 24),
-                      RoundButton(
-                        title: context.localize(_registerText),
-                        onPressed: () {
-                          context.push(AppRoute.completeProfile);
-                        },
-                      ),
-                      const SizedBox(height: 16),
-                      Row(
-                        children: [
-                          Expanded(
-                            child: Container(
-                              height: 1,
-                              color: TColor.gray.withValues(alpha: 0.3),
-                            ),
-                          ),
-                          const SizedBox(width: 8),
-                          Text(
-                            context.localize(_dividerText),
-                            style: TextStyle(color: TColor.black, fontSize: 12),
-                          ),
-                          const SizedBox(width: 8),
-                          Expanded(
-                            child: Container(
-                              height: 1,
-                              color: TColor.gray.withValues(alpha: 0.3),
-                            ),
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 16),
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: const [
-                          SocialAuthButton(assetPath: 'assets/img/google.png'),
-                          SizedBox(width: 16),
-                          SocialAuthButton(
-                            assetPath: 'assets/img/facebook.png',
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 20),
-                      TextButton(
-                        onPressed: () {
-                          context.push(AppRoute.login);
-                        },
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Text(
-                              context.localize(_footerQuestionText),
-                              style: TextStyle(
-                                color: TColor.black,
-                                fontSize: 14,
-                              ),
-                            ),
-                            Text(
-                              context.localize(_footerActionText),
-                              style: TextStyle(
-                                color: TColor.black,
-                                fontSize: 14,
-                                fontWeight: FontWeight.w700,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                      const SizedBox(height: 24),
-                    ],
-                  ),
+                  child: _buildContent(context),
                 ),
               ),
             );
@@ -240,5 +146,296 @@ class _SignUpViewState extends State<SignUpView> {
         ),
       ),
     );
+  }
+
+  Widget _buildContent(BuildContext context) {
+    final autovalidateMode =
+        _autoValidate ? AutovalidateMode.onUserInteraction : AutovalidateMode.disabled;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        const SizedBox(height: 24),
+        Text(
+          context.localize(_greetingText),
+          textAlign: TextAlign.center,
+          style: TextStyle(color: TColor.gray, fontSize: 16),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          context.localize(_createAccountText),
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            color: TColor.black,
+            fontSize: 24,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        const SizedBox(height: 28),
+        Form(
+          key: _formKey,
+          autovalidateMode: autovalidateMode,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              RoundTextField(
+                controller: _firstNameController,
+                focusNode: _firstNameFocusNode,
+                hintText: context.localize(_firstNameHint),
+                icon: 'assets/img/user_text.png',
+                textCapitalization: TextCapitalization.words,
+                textInputAction: TextInputAction.next,
+                autovalidateMode: autovalidateMode,
+                validator: _validateFirstName,
+                onChanged: _onFieldChanged,
+                onFieldSubmitted: (_) => _lastNameFocusNode.requestFocus(),
+              ),
+              const SizedBox(height: 16),
+              RoundTextField(
+                controller: _lastNameController,
+                focusNode: _lastNameFocusNode,
+                hintText: context.localize(_lastNameHint),
+                icon: 'assets/img/user_text.png',
+                textCapitalization: TextCapitalization.words,
+                textInputAction: TextInputAction.next,
+                autovalidateMode: autovalidateMode,
+                validator: _validateLastName,
+                onChanged: _onFieldChanged,
+                onFieldSubmitted: (_) => _emailFocusNode.requestFocus(),
+              ),
+              const SizedBox(height: 16),
+              RoundTextField(
+                controller: _emailController,
+                focusNode: _emailFocusNode,
+                hintText: context.localize(_emailHint),
+                icon: 'assets/img/email.png',
+                keyboardType: TextInputType.emailAddress,
+                textInputAction: TextInputAction.next,
+                autovalidateMode: autovalidateMode,
+                validator: _validateEmail,
+                onChanged: _onFieldChanged,
+                onFieldSubmitted: (_) => _passwordFocusNode.requestFocus(),
+              ),
+              const SizedBox(height: 16),
+              RoundTextField(
+                controller: _passwordController,
+                focusNode: _passwordFocusNode,
+                hintText: context.localize(_passwordHint),
+                icon: 'assets/img/lock.png',
+                obscureText: !_isPasswordVisible,
+                textInputAction: TextInputAction.done,
+                autovalidateMode: autovalidateMode,
+                validator: _validatePassword,
+                onChanged: _onFieldChanged,
+                onFieldSubmitted: (_) => _onRegisterPressed(),
+                rightIcon: IconButton(
+                  padding: EdgeInsets.zero,
+                  constraints: const BoxConstraints(),
+                  onPressed: () {
+                    setState(() {
+                      _isPasswordVisible = !_isPasswordVisible;
+                    });
+                  },
+                  icon: Image.asset(
+                    _isPasswordVisible
+                        ? 'assets/img/hide_password.png'
+                        : 'assets/img/show_password.png',
+                    width: 20,
+                    height: 20,
+                    color: TColor.gray,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 12),
+        _buildTermsRow(context),
+        if (_showTermsError && !_isTermsAccepted) ...[
+          const SizedBox(height: 4),
+          Text(
+            context.localize(_termsRequiredError),
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.error,
+              fontSize: 12,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ],
+        const SizedBox(height: 24),
+        RoundButton(
+          title: context.localize(_registerText),
+          onPressed: _onRegisterPressed,
+          isEnabled: _isRegisterEnabled && _isTermsAccepted,
+        ),
+        const SizedBox(height: 16),
+        Row(
+          children: [
+            Expanded(
+              child: Container(
+                height: 1,
+                color: TColor.gray.withValues(alpha: 0.3),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Text(
+              context.localize(_dividerText),
+              style: TextStyle(color: TColor.black, fontSize: 12),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Container(
+                height: 1,
+                color: TColor.gray.withValues(alpha: 0.3),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 16),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: const [
+            SocialAuthButton(assetPath: 'assets/img/google.png'),
+            SizedBox(width: 16),
+            SocialAuthButton(
+              assetPath: 'assets/img/facebook.png',
+            ),
+          ],
+        ),
+        const SizedBox(height: 20),
+        TextButton(
+          onPressed: () {
+            context.push(AppRoute.login);
+          },
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                context.localize(_footerQuestionText),
+                style: TextStyle(
+                  color: TColor.black,
+                  fontSize: 14,
+                ),
+              ),
+              Text(
+                context.localize(_footerActionText),
+                style: TextStyle(
+                  color: TColor.black,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 24),
+      ],
+    );
+  }
+
+  Widget _buildTermsRow(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Checkbox(
+          value: _isTermsAccepted,
+          onChanged: (value) {
+            setState(() {
+              _isTermsAccepted = value ?? false;
+              if (_isTermsAccepted) {
+                _showTermsError = false;
+              }
+            });
+            _onFieldChanged('');
+          },
+          visualDensity: VisualDensity.compact,
+          materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        ),
+        const SizedBox(width: 4),
+        Expanded(
+          child: Text(
+            context.localize(_termsText),
+            style: TextStyle(
+              color: TColor.gray,
+              fontSize: 12,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _onFieldChanged(String _) {
+    final isValid = _canSubmitForm();
+    if (isValid != _isRegisterEnabled) {
+      setState(() {
+        _isRegisterEnabled = isValid;
+      });
+    }
+  }
+
+  void _onRegisterPressed() {
+    final form = _formKey.currentState;
+    if (form == null) {
+      return;
+    }
+
+    setState(() {
+      _autoValidate = true;
+      _showTermsError = !_isTermsAccepted;
+    });
+
+    if (!form.validate() || !_isTermsAccepted) {
+      _onFieldChanged('');
+      return;
+    }
+
+    context.push(AppRoute.completeProfile);
+  }
+
+  String? _validateFirstName(String? value) {
+    final text = value?.trim() ?? '';
+    if (text.isEmpty) {
+      return context.localize(_firstNameRequiredError);
+    }
+    return null;
+  }
+
+  String? _validateLastName(String? value) {
+    final text = value?.trim() ?? '';
+    if (text.isEmpty) {
+      return context.localize(_lastNameRequiredError);
+    }
+    return null;
+  }
+
+  String? _validateEmail(String? value) {
+    final text = value?.trim() ?? '';
+    if (text.isEmpty) {
+      return context.localize(_emailRequiredError);
+    }
+    if (!_emailRegExp.hasMatch(text)) {
+      return context.localize(_emailInvalidError);
+    }
+    return null;
+  }
+
+  String? _validatePassword(String? value) {
+    final text = value ?? '';
+    if (text.isEmpty) {
+      return context.localize(_passwordRequiredError);
+    }
+    if (text.length < 8) {
+      return context.localize(_passwordLengthError);
+    }
+    return null;
+  }
+
+  bool _canSubmitForm() {
+    return _validateFirstName(_firstNameController.text) == null &&
+        _validateLastName(_lastNameController.text) == null &&
+        _validateEmail(_emailController.text) == null &&
+        _validatePassword(_passwordController.text) == null;
   }
 }

--- a/lib/view/workout_tracker/add_schedule_view.dart
+++ b/lib/view/workout_tracker/add_schedule_view.dart
@@ -1,24 +1,56 @@
+import 'package:aigymbuddy/common/color_extension.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../common/color_extension.dart';
 import '../../common/date_time_utils.dart';
 import '../../common_widget/icon_title_next_row.dart';
 import '../../common_widget/round_button.dart';
 
 class AddScheduleView extends StatefulWidget {
-  final DateTime date;
   const AddScheduleView({super.key, required this.date});
+
+  final DateTime date;
 
   @override
   State<AddScheduleView> createState() => _AddScheduleViewState();
 }
 
 class _AddScheduleViewState extends State<AddScheduleView> {
+  late DateTime _selectedDateTime;
+  String _selectedWorkout = 'Upperbody Workout';
+  String _selectedDifficulty = 'Beginner';
+  int? _customRepetitions;
+  double? _customWeight;
+
+  static const List<String> _workoutOptions = <String>[
+    'Upperbody Workout',
+    'Fullbody Workout',
+    'Lowerbody Workout',
+    'Core Burner',
+  ];
+
+  static const List<String> _difficultyOptions = <String>[
+    'Beginner',
+    'Intermediate',
+    'Advanced',
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedDateTime = DateTime(
+      widget.date.year,
+      widget.date.month,
+      widget.date.day,
+      widget.date.hour,
+      widget.date.minute,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
-    var media = MediaQuery.of(context).size;
+    final media = MediaQuery.of(context).size;
 
     return Scaffold(
       appBar: AppBar(
@@ -107,11 +139,17 @@ class _AddScheduleViewState extends State<AddScheduleView> {
             SizedBox(
               height: media.width * 0.35,
               child: CupertinoDatePicker(
-                onDateTimeChanged: (newDate) {},
-                initialDateTime: DateTime.now(),
+                initialDateTime: DateTime(
+                  widget.date.year,
+                  widget.date.month,
+                  widget.date.day,
+                  _selectedDateTime.hour,
+                  _selectedDateTime.minute,
+                ),
                 use24hFormat: false,
                 minuteInterval: 1,
                 mode: CupertinoDatePickerMode.time,
+                onDateTimeChanged: _handleTimeChanged,
               ),
             ),
             const SizedBox(height: 20),
@@ -127,40 +165,193 @@ class _AddScheduleViewState extends State<AddScheduleView> {
             IconTitleNextRow(
               icon: "assets/img/choose_workout.png",
               title: "Choose Workout",
-              time: "Upperbody",
+              time: _selectedWorkout,
               color: TColor.lightGray,
-              onPressed: () {},
+              onPressed: _pickWorkout,
             ),
             const SizedBox(height: 10),
             IconTitleNextRow(
               icon: "assets/img/difficulity.png",
               title: "Difficulity",
-              time: "Beginner",
+              time: _selectedDifficulty,
               color: TColor.lightGray,
-              onPressed: () {},
+              onPressed: _pickDifficulty,
             ),
             const SizedBox(height: 10),
             IconTitleNextRow(
               icon: "assets/img/repetitions.png",
               title: "Custom Repetitions",
-              time: "",
+              time: _customRepetitions == null
+                  ? 'Not set'
+                  : '${_customRepetitions!} reps',
               color: TColor.lightGray,
-              onPressed: () {},
+              onPressed: _pickRepetitions,
             ),
             const SizedBox(height: 10),
             IconTitleNextRow(
               icon: "assets/img/repetitions.png",
               title: "Custom Weights",
-              time: "",
+              time: _customWeight == null
+                  ? 'Not set'
+                  : '${_customWeight!.toStringAsFixed(1)} kg',
               color: TColor.lightGray,
-              onPressed: () {},
+              onPressed: _pickWeight,
             ),
             const Spacer(),
-            RoundButton(title: "Save", onPressed: () {}),
+            RoundButton(title: "Save", onPressed: _handleSave),
             const SizedBox(height: 20),
           ],
         ),
       ),
+    );
+  }
+
+  void _handleTimeChanged(DateTime newDate) {
+    setState(() {
+      _selectedDateTime = DateTime(
+        widget.date.year,
+        widget.date.month,
+        widget.date.day,
+        newDate.hour,
+        newDate.minute,
+      );
+    });
+  }
+
+  Future<void> _pickWorkout() async {
+    final selected = await _showOptionPicker<String>(
+      title: 'Choose Workout',
+      options: _workoutOptions,
+      currentValue: _selectedWorkout,
+    );
+    if (selected != null) {
+      setState(() => _selectedWorkout = selected);
+    }
+  }
+
+  Future<void> _pickDifficulty() async {
+    final selected = await _showOptionPicker<String>(
+      title: 'Select Difficulty',
+      options: _difficultyOptions,
+      currentValue: _selectedDifficulty,
+    );
+    if (selected != null) {
+      setState(() => _selectedDifficulty = selected);
+    }
+  }
+
+  Future<void> _pickRepetitions() async {
+    final options = List<int>.generate(20, (index) => (index + 1) * 5);
+    final selected = await _showOptionPicker<int>(
+      title: 'Custom Repetitions',
+      options: options,
+      currentValue: _customRepetitions,
+      labelBuilder: (value) => '$value reps',
+    );
+    if (selected != null) {
+      setState(() => _customRepetitions = selected);
+    }
+  }
+
+  Future<void> _pickWeight() async {
+    final options = List<double>.generate(16, (index) => 5 + (index * 2.5));
+    final selected = await _showOptionPicker<double>(
+      title: 'Custom Weights',
+      options: options,
+      currentValue: _customWeight,
+      labelBuilder: (value) => '${value.toStringAsFixed(1)} kg',
+    );
+    if (selected != null) {
+      setState(() => _customWeight = selected);
+    }
+  }
+
+  Future<T?> _showOptionPicker<T>({
+    required String title,
+    required List<T> options,
+    T? currentValue,
+    String Function(T value)? labelBuilder,
+  }) {
+    return showModalBottomSheet<T>(
+      context: context,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (context) {
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 16),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(
+                  width: 40,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: TColor.gray.withValues(alpha: 0.3),
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20),
+                  child: Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      title,
+                      style: TextStyle(
+                        color: TColor.black,
+                        fontSize: 16,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 8),
+                ...options.map((option) {
+                  final label = labelBuilder != null
+                      ? labelBuilder(option)
+                      : option.toString();
+                  final isSelected = currentValue != null && option == currentValue;
+                  return ListTile(
+                    title: Text(label),
+                    trailing: isSelected
+                        ? Icon(Icons.check, color: TColor.primaryColor2)
+                        : null,
+                    onTap: () => context.pop(option),
+                  );
+                }),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  void _handleSave() {
+    final messenger = ScaffoldMessenger.of(context);
+    final formattedDate = DateTimeUtils.formatDate(
+      _selectedDateTime,
+      pattern: 'E, dd MMM yyyy • h:mm a',
+    );
+
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(
+          'Schedule saved for $formattedDate',
+        ),
+      ),
+    );
+
+    context.pop(
+      {
+        'date': _selectedDateTime,
+        'workout': _selectedWorkout,
+        'difficulty': _selectedDifficulty,
+        'repetitions': _customRepetitions,
+        'weight': _customWeight,
+      },
     );
   }
 }

--- a/lib/view/workout_tracker/exercises_step_details.dart
+++ b/lib/view/workout_tracker/exercises_step_details.dart
@@ -146,7 +146,13 @@ class ExercisesStepDetails extends StatelessWidget {
                     ),
                   ),
                   IconButton(
-                    onPressed: () {},
+                    onPressed: () {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content: Text('Video preview will be available soon.'),
+                        ),
+                      );
+                    },
                     icon: Image.asset(
                       "assets/img/Play.png",
                       width: 30,
@@ -205,7 +211,7 @@ class ExercisesStepDetails extends StatelessWidget {
                     ),
                   ),
                   TextButton(
-                    onPressed: () {},
+                    onPressed: () => _showStepsSummary(context),
                     child: Text(
                       "${_steps.length} Sets",
                       style: TextStyle(color: TColor.gray, fontSize: 12),
@@ -286,7 +292,16 @@ class ExercisesStepDetails extends StatelessWidget {
                   },
                 ),
               ),
-              RoundButton(title: "Save", elevation: 0, onPressed: () {}),
+              RoundButton(
+                title: "Save",
+                elevation: 0,
+                onPressed: () {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Exercise saved.')),
+                  );
+                  context.pop();
+                },
+              ),
               const SizedBox(height: 15),
             ],
           ),
@@ -294,4 +309,61 @@ class ExercisesStepDetails extends StatelessWidget {
       ),
     );
   }
+}
+
+void _showStepsSummary(BuildContext context) {
+  showModalBottomSheet<void>(
+    context: context,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+    ),
+    builder: (context) {
+      return SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: TColor.gray.withValues(alpha: 0.3),
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+              const SizedBox(height: 16),
+              Text(
+                'Step Summary',
+                style: TextStyle(
+                  color: TColor.black,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 12),
+              ...ExercisesStepDetails._steps.map(
+                (step) => ListTile(
+                  title: Text(step.title),
+                  subtitle: Text(step.description),
+                  leading: CircleAvatar(
+                    radius: 16,
+                    backgroundColor: TColor.primaryColor2.withValues(alpha: 0.15),
+                    child: Text(
+                      step.number,
+                      style: TextStyle(
+                        color: TColor.primaryColor2,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    },
+  );
 }

--- a/lib/view/workout_tracker/workour_detail_view.dart
+++ b/lib/view/workout_tracker/workour_detail_view.dart
@@ -17,26 +17,13 @@ class WorkoutDetailView extends StatefulWidget {
 }
 
 class _WorkoutDetailViewState extends State<WorkoutDetailView> {
-  List latestArr = [
-    {
-      "image": "assets/img/Workout1.png",
-      "title": "Fullbody Workout",
-      "time": "Today, 03:00pm",
-    },
-    {
-      "image": "assets/img/Workout2.png",
-      "title": "Upperbody Workout",
-      "time": "June 05, 02:00pm",
-    },
-  ];
-
-  List youArr = [
+  final List<Map<String, String>> youArr = [
     {"image": "assets/img/barbell.png", "title": "Barbell"},
     {"image": "assets/img/skipping_rope.png", "title": "Skipping Rope"},
     {"image": "assets/img/bottle.png", "title": "Bottle 1 Liters"},
   ];
 
-  List exercisesArr = [
+  final List<Map<String, dynamic>> exercisesArr = [
     {
       "name": "Set 1",
       "set": [
@@ -84,6 +71,8 @@ class _WorkoutDetailViewState extends State<WorkoutDetailView> {
       ],
     },
   ];
+
+  bool _isFavorite = false;
 
   @override
   Widget build(BuildContext context) {
@@ -213,12 +202,15 @@ class _WorkoutDetailViewState extends State<WorkoutDetailView> {
                             ),
                           ),
                           TextButton(
-                            onPressed: () {},
+                            onPressed: _toggleFavorite,
                             child: Image.asset(
                               "assets/img/fav.png",
                               width: 15,
                               height: 15,
                               fit: BoxFit.contain,
+                              color: _isFavorite
+                                  ? TColor.secondaryColor2
+                                  : null,
                             ),
                           ),
                         ],
@@ -239,7 +231,7 @@ class _WorkoutDetailViewState extends State<WorkoutDetailView> {
                         title: "Difficulity",
                         time: "Beginner",
                         color: TColor.secondaryColor2.withValues(alpha: 0.3),
-                        onPressed: () {},
+                        onPressed: _showDifficultyInfo,
                       ),
                       SizedBox(height: media.width * 0.05),
                       Row(
@@ -254,7 +246,7 @@ class _WorkoutDetailViewState extends State<WorkoutDetailView> {
                             ),
                           ),
                           TextButton(
-                            onPressed: () {},
+                            onPressed: _showEquipmentSheet,
                             child: Text(
                               "${youArr.length} Items",
                               style: TextStyle(
@@ -323,7 +315,7 @@ class _WorkoutDetailViewState extends State<WorkoutDetailView> {
                             ),
                           ),
                           TextButton(
-                            onPressed: () {},
+                            onPressed: _showExerciseSummary,
                             child: Text(
                               "${youArr.length} Sets",
                               style: TextStyle(
@@ -363,7 +355,10 @@ class _WorkoutDetailViewState extends State<WorkoutDetailView> {
                     mainAxisSize: MainAxisSize.max,
                     mainAxisAlignment: MainAxisAlignment.end,
                     children: [
-                      RoundButton(title: "Start Workout", onPressed: () {}),
+                      RoundButton(
+                        title: "Start Workout",
+                        onPressed: _startWorkout,
+                      ),
                     ],
                   ),
                 ),
@@ -372,6 +367,187 @@ class _WorkoutDetailViewState extends State<WorkoutDetailView> {
           ),
         ),
       ),
+    );
+  }
+
+  void _toggleFavorite() {
+    setState(() => _isFavorite = !_isFavorite);
+    final messenger = ScaffoldMessenger.of(context);
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(
+          _isFavorite ? 'Added to favourites' : 'Removed from favourites',
+        ),
+      ),
+    );
+  }
+
+  Future<void> _showDifficultyInfo() async {
+    await showModalBottomSheet<void>(
+      context: context,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (context) {
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Difficulty Levels',
+                  style: TextStyle(
+                    color: TColor.black,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  'Beginner workouts focus on mastering form and building a consistent routine. '
+                  'Increase to Intermediate or Advanced once you can complete every set without breaking form.',
+                  style: TextStyle(color: TColor.gray, fontSize: 13),
+                ),
+                const SizedBox(height: 12),
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('Got it'),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _showEquipmentSheet() async {
+    await showModalBottomSheet<void>(
+      context: context,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (context) {
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 16),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(
+                  width: 40,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: TColor.gray.withValues(alpha: 0.3),
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  "You'll Need",
+                  style: TextStyle(
+                    color: TColor.black,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                ...youArr.map((item) {
+                  return ListTile(
+                    leading: Image.asset(
+                      item['image']!,
+                      width: 32,
+                      height: 32,
+                      fit: BoxFit.contain,
+                    ),
+                    title: Text(
+                      item['title']!,
+                      style: TextStyle(color: TColor.black),
+                    ),
+                  );
+                }),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _showExerciseSummary() async {
+    await showModalBottomSheet<void>(
+      context: context,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (context) {
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 16),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(
+                  width: 40,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: TColor.gray.withValues(alpha: 0.3),
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  'Exercises Overview',
+                  style: TextStyle(
+                    color: TColor.black,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                ...exercisesArr.map((set) {
+                  final exercises =
+                      (set['set'] as List<dynamic>? ?? const []).length;
+                  return ListTile(
+                    title: Text(
+                      set['name'].toString(),
+                      style: TextStyle(color: TColor.black),
+                    ),
+                    subtitle: Text(
+                      '$exercises exercises',
+                      style: TextStyle(color: TColor.gray),
+                    ),
+                  );
+                }),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  void _startWorkout() {
+    final firstSet = exercisesArr.isNotEmpty ? exercisesArr.first : null;
+    final setItems = firstSet != null
+        ? (firstSet['set'] as List<dynamic>? ?? const [])
+        : const [];
+    if (setItems.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('No exercises available yet.')),
+      );
+      return;
+    }
+
+    final firstExercise = Map<String, dynamic>.from(
+      setItems.first as Map,
+    );
+
+    context.push(
+      AppRoute.exerciseSteps,
+      extra: ExerciseStepsArgs(exercise: firstExercise),
     );
   }
 }

--- a/lib/view/workout_tracker/workout_schedule_view.dart
+++ b/lib/view/workout_tracker/workout_schedule_view.dart
@@ -21,6 +21,8 @@ class _WorkoutScheduleViewState extends State<WorkoutScheduleView> {
   final CalendarAgendaController _calendarAgendaControllerAppBar =
       CalendarAgendaController();
   late DateTime _selectedDateAppBBar;
+  late final DateTime _firstAvailableDate;
+  late final DateTime _lastAvailableDate;
 
   final List<Map<String, String>> eventArr = [
     {"name": "Ab Workout", "start_time": "25/05/2023 07:30 AM"},
@@ -39,7 +41,10 @@ class _WorkoutScheduleViewState extends State<WorkoutScheduleView> {
   @override
   void initState() {
     super.initState();
-    _selectedDateAppBBar = DateTime.now();
+    final now = DateTime.now();
+    _selectedDateAppBBar = now;
+    _firstAvailableDate = now.subtract(const Duration(days: 140));
+    _lastAvailableDate = now.add(const Duration(days: 60));
     setDayEventWorkoutList();
   }
 
@@ -102,7 +107,7 @@ class _WorkoutScheduleViewState extends State<WorkoutScheduleView> {
         ),
         actions: [
           InkWell(
-            onTap: () {},
+            onTap: _navigateToAddSchedule,
             child: Container(
               margin: const EdgeInsets.all(8),
               height: 40,
@@ -131,13 +136,29 @@ class _WorkoutScheduleViewState extends State<WorkoutScheduleView> {
             controller: _calendarAgendaControllerAppBar,
             appbar: false,
             selectedDayPosition: SelectedDayPosition.center,
-            leading: IconButton(
-              onPressed: () {},
-              icon: Image.asset(
-                "assets/img/ArrowLeft.png",
-                width: 15,
-                height: 15,
-              ),
+            leading: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                IconButton(
+                  onPressed: () => _changeSelectedDay(-1),
+                  icon: Image.asset(
+                    "assets/img/ArrowLeft.png",
+                    width: 15,
+                    height: 15,
+                  ),
+                ),
+                IconButton(
+                  onPressed: () => _changeSelectedDay(1),
+                  icon: Transform.flip(
+                    flipX: true,
+                    child: Image.asset(
+                      "assets/img/ArrowLeft.png",
+                      width: 15,
+                      height: 15,
+                    ),
+                  ),
+                ),
+              ],
             ),
             // NOTE: 'training' parameter tidak ada di paket → dihapus
             weekDay: WeekDay.short,
@@ -147,10 +168,10 @@ class _WorkoutScheduleViewState extends State<WorkoutScheduleView> {
             selectedDateColor: Colors.white,
             dateColor: Colors.black,
             locale: 'en',
-            initialDate: DateTime.now(),
+            initialDate: _selectedDateAppBBar,
             calendarEventColor: TColor.primaryColor2,
-            firstDate: DateTime.now().subtract(const Duration(days: 140)),
-            lastDate: DateTime.now().add(const Duration(days: 60)),
+            firstDate: _firstAvailableDate,
+            lastDate: _lastAvailableDate,
             onDateSelected: (date) {
               _selectedDateAppBBar = date;
               setDayEventWorkoutList();
@@ -196,156 +217,19 @@ class _WorkoutScheduleViewState extends State<WorkoutScheduleView> {
                             Expanded(
                               child: Stack(
                                 alignment: Alignment.centerLeft,
-                                children: slotArr.map((sObj) {
-                                  final min = (sObj["date"] as DateTime).minute;
-                                  // range (-1 .. 1)
+                                children: slotArr.map((raw) {
+                                  final schedule =
+                                      Map<String, dynamic>.from(raw);
+                                  final date =
+                                      schedule["date"] as DateTime;
+                                  final min = date.minute;
                                   final pos = (min / 60) * 2 - 1;
 
                                   return Align(
                                     alignment: Alignment(pos, 0),
                                     child: InkWell(
-                                      onTap: () {
-                                        showDialog(
-                                          context: context,
-                                          builder: (context) {
-                                            return AlertDialog(
-                                              backgroundColor:
-                                                  Colors.transparent,
-                                              contentPadding: EdgeInsets.zero,
-                                              content: Container(
-                                                padding:
-                                                    const EdgeInsets.symmetric(
-                                                      vertical: 15,
-                                                      horizontal: 20,
-                                                    ),
-                                                decoration: BoxDecoration(
-                                                  color: TColor.white,
-                                                  borderRadius:
-                                                      BorderRadius.circular(20),
-                                                ),
-                                                child: Column(
-                                                  mainAxisSize:
-                                                      MainAxisSize.min,
-                                                  crossAxisAlignment:
-                                                      CrossAxisAlignment.start,
-                                                  children: [
-                                                    Row(
-                                                      mainAxisAlignment:
-                                                          MainAxisAlignment
-                                                              .spaceBetween,
-                                                      children: [
-                                                        InkWell(
-                                                          onTap: () =>
-                                                              context.pop(),
-                                                          child: Container(
-                                                            margin:
-                                                                const EdgeInsets.all(
-                                                                  8,
-                                                                ),
-                                                            height: 40,
-                                                            width: 40,
-                                                            alignment: Alignment
-                                                                .center,
-                                                            decoration:
-                                                                BoxDecoration(
-                                                                  color: TColor
-                                                                      .lightGray,
-                                                                  borderRadius:
-                                                                      BorderRadius.circular(
-                                                                        10,
-                                                                      ),
-                                                                ),
-                                                            child: Image.asset(
-                                                              "assets/img/closed_btn.png",
-                                                              width: 15,
-                                                              height: 15,
-                                                              fit: BoxFit
-                                                                  .contain,
-                                                            ),
-                                                          ),
-                                                        ),
-                                                        Text(
-                                                          "Workout Schedule",
-                                                          style: TextStyle(
-                                                            color: TColor.black,
-                                                            fontSize: 16,
-                                                            fontWeight:
-                                                                FontWeight.w700,
-                                                          ),
-                                                        ),
-                                                        InkWell(
-                                                          onTap: () {},
-                                                          child: Container(
-                                                            margin:
-                                                                const EdgeInsets.all(
-                                                                  8,
-                                                                ),
-                                                            height: 40,
-                                                            width: 40,
-                                                            alignment: Alignment
-                                                                .center,
-                                                            decoration:
-                                                                BoxDecoration(
-                                                                  color: TColor
-                                                                      .lightGray,
-                                                                  borderRadius:
-                                                                      BorderRadius.circular(
-                                                                        10,
-                                                                      ),
-                                                                ),
-                                                            child: Image.asset(
-                                                              "assets/img/more_btn.png",
-                                                              width: 15,
-                                                              height: 15,
-                                                              fit: BoxFit
-                                                                  .contain,
-                                                            ),
-                                                          ),
-                                                        ),
-                                                      ],
-                                                    ),
-                                                    const SizedBox(height: 15),
-                                                    Text(
-                                                      sObj["name"].toString(),
-                                                      style: TextStyle(
-                                                        color: TColor.black,
-                                                        fontSize: 14,
-                                                        fontWeight:
-                                                            FontWeight.w700,
-                                                      ),
-                                                    ),
-                                                    const SizedBox(height: 4),
-                                                    Row(
-                                                      children: [
-                                                        Image.asset(
-                                                          "assets/img/time_workout.png",
-                                                          height: 20,
-                                                          width: 20,
-                                                        ),
-                                                        const SizedBox(
-                                                          width: 8,
-                                                        ),
-                                                        Text(
-                                                          "${DateTimeUtils.describeDayFromString(sObj["start_time"].toString())} | ${DateTimeUtils.reformatDateString(sObj["start_time"].toString(), outputPattern: "h:mm aa")}",
-                                                          style: TextStyle(
-                                                            color: TColor.gray,
-                                                            fontSize: 12,
-                                                          ),
-                                                        ),
-                                                      ],
-                                                    ),
-                                                    const SizedBox(height: 15),
-                                                    RoundButton(
-                                                      title: "Mark Done",
-                                                      onPressed: () {},
-                                                    ),
-                                                  ],
-                                                ),
-                                              ),
-                                            );
-                                          },
-                                        );
-                                      },
+                                      onTap: () =>
+                                          _showWorkoutDialog(schedule),
                                       child: Container(
                                         height: 35,
                                         width: availWidth * 0.5,
@@ -362,7 +246,7 @@ class _WorkoutScheduleViewState extends State<WorkoutScheduleView> {
                                           ),
                                         ),
                                         child: Text(
-                                          "${sObj["name"]}, ${DateTimeUtils.reformatDateString(sObj["start_time"].toString(), outputPattern: "h:mm aa")}",
+                                          "${schedule["name"]}, ${DateTimeUtils.reformatDateString(schedule["start_time"].toString(), outputPattern: "h:mm aa")}",
                                           maxLines: 1,
                                           overflow: TextOverflow.ellipsis,
                                           style: TextStyle(
@@ -387,12 +271,7 @@ class _WorkoutScheduleViewState extends State<WorkoutScheduleView> {
         ],
       ),
       floatingActionButton: InkWell(
-        onTap: () {
-          context.push(
-            AppRoute.addWorkoutSchedule,
-            extra: AddScheduleArgs(date: _selectedDateAppBBar),
-          );
-        },
+        onTap: _navigateToAddSchedule,
         child: Container(
           width: 55,
           height: 55,
@@ -412,5 +291,145 @@ class _WorkoutScheduleViewState extends State<WorkoutScheduleView> {
         ),
       ),
     );
+  }
+
+  void _changeSelectedDay(int offsetDays) {
+    final target = _selectedDateAppBBar.add(Duration(days: offsetDays));
+    final clamped = target.isBefore(_firstAvailableDate)
+        ? _firstAvailableDate
+        : target.isAfter(_lastAvailableDate)
+            ? _lastAvailableDate
+            : target;
+    _selectedDateAppBBar = clamped;
+    _calendarAgendaControllerAppBar.goToDay(clamped);
+    setDayEventWorkoutList();
+  }
+
+  void _navigateToAddSchedule() {
+    context.push(
+      AppRoute.addWorkoutSchedule,
+      extra: AddScheduleArgs(date: _selectedDateAppBBar),
+    );
+  }
+
+  Future<void> _showWorkoutDialog(Map<String, dynamic> schedule) async {
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          backgroundColor: Colors.transparent,
+          contentPadding: EdgeInsets.zero,
+          content: Container(
+            padding: const EdgeInsets.symmetric(vertical: 15, horizontal: 20),
+            decoration: BoxDecoration(
+              color: TColor.white,
+              borderRadius: BorderRadius.circular(20),
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    InkWell(
+                      onTap: () => Navigator.of(dialogContext).pop(false),
+                      child: Container(
+                        margin: const EdgeInsets.all(8),
+                        height: 40,
+                        width: 40,
+                        alignment: Alignment.center,
+                        decoration: BoxDecoration(
+                          color: TColor.lightGray,
+                          borderRadius: BorderRadius.circular(10),
+                        ),
+                        child: Image.asset(
+                          "assets/img/closed_btn.png",
+                          width: 15,
+                          height: 15,
+                          fit: BoxFit.contain,
+                        ),
+                      ),
+                    ),
+                    Text(
+                      "Workout Schedule",
+                      style: TextStyle(
+                        color: TColor.black,
+                        fontSize: 16,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    InkWell(
+                      onTap: () {
+                        Navigator.of(dialogContext).pop(false);
+                        _navigateToAddSchedule();
+                      },
+                      child: Container(
+                        margin: const EdgeInsets.all(8),
+                        height: 40,
+                        width: 40,
+                        alignment: Alignment.center,
+                        decoration: BoxDecoration(
+                          color: TColor.lightGray,
+                          borderRadius: BorderRadius.circular(10),
+                        ),
+                        child: Image.asset(
+                          "assets/img/more_btn.png",
+                          width: 15,
+                          height: 15,
+                          fit: BoxFit.contain,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 15),
+                Text(
+                  schedule["name"].toString(),
+                  style: TextStyle(
+                    color: TColor.black,
+                    fontSize: 14,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Row(
+                  children: [
+                    Image.asset(
+                      "assets/img/time_workout.png",
+                      height: 20,
+                      width: 20,
+                    ),
+                    const SizedBox(width: 8),
+                    Text(
+                      "${DateTimeUtils.describeDayFromString(schedule["start_time"].toString())} | ${DateTimeUtils.reformatDateString(schedule["start_time"].toString(), outputPattern: "h:mm aa")}",
+                      style: TextStyle(
+                        color: TColor.gray,
+                        fontSize: 12,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 15),
+                RoundButton(
+                  title: "Mark Done",
+                  onPressed: () => Navigator.of(dialogContext).pop(true),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+
+    if (result == true && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            'Marked ${schedule["name"]} as done',
+          ),
+        ),
+      );
+    }
   }
 }

--- a/lib/view/workout_tracker/workout_tracker_view.dart
+++ b/lib/view/workout_tracker/workout_tracker_view.dart
@@ -99,7 +99,7 @@ class _WorkoutTrackerViewState extends State<WorkoutTrackerView> {
               ),
               actions: [
                 InkWell(
-                  onTap: () {},
+                  onTap: _showMoreActions,
                   child: Container(
                     margin: const EdgeInsets.all(8),
                     height: 40,
@@ -269,9 +269,7 @@ class _WorkoutTrackerViewState extends State<WorkoutTrackerView> {
                             type: RoundButtonType.bgGradient,
                             fontSize: 12,
                             fontWeight: FontWeight.w400,
-                            onPressed: () {
-                              // Navigate ke halaman schedule kalau sudah ada
-                            },
+                            onPressed: _handleOpenSchedule,
                           ),
                         ),
                       ],
@@ -293,7 +291,7 @@ class _WorkoutTrackerViewState extends State<WorkoutTrackerView> {
                         ),
                       ),
                       TextButton(
-                        onPressed: () {},
+                        onPressed: _handleOpenSchedule,
                         child: Text(
                           "See More",
                           style: TextStyle(
@@ -312,9 +310,12 @@ class _WorkoutTrackerViewState extends State<WorkoutTrackerView> {
                     itemCount: latestArr.length,
                     itemBuilder: (context, index) {
                       final wObj = latestArr[index];
-                      // UpcomingWorkoutRow biasanya ambil Map<String, dynamic>
-                      return UpcomingWorkoutRow(
-                        wObj: Map<String, dynamic>.from(wObj),
+                      final workout = Map<String, String>.from(wObj);
+                      return InkWell(
+                        onTap: () => _handleOpenWorkoutDetail(workout),
+                        child: UpcomingWorkoutRow(
+                          wObj: Map<String, dynamic>.from(wObj),
+                        ),
                       );
                     },
                   ),
@@ -366,6 +367,77 @@ class _WorkoutTrackerViewState extends State<WorkoutTrackerView> {
           ),
         ),
       ),
+    );
+  }
+
+  void _handleOpenSchedule() {
+    if (!mounted) return;
+    context.push(AppRoute.workoutSchedule);
+  }
+
+  void _handleOpenWorkoutDetail(Map<String, String> workout) {
+    if (!mounted) return;
+
+    final detailData = <String, dynamic>{
+      'title': workout['title'] ?? 'Workout',
+      'time': workout['time'] ?? 'Today, 03:00pm',
+      'exercises': workout['exercises'] ?? '11 Exercises',
+      'image': workout['image'],
+    };
+
+    context.push(
+      AppRoute.workoutDetail,
+      extra: WorkoutDetailArgs(workout: detailData),
+    );
+  }
+
+  void _showMoreActions() {
+    showModalBottomSheet<void>(
+      context: context,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (context) {
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 20),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(
+                  width: 40,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: TColor.gray.withValues(alpha: 0.3),
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                ListTile(
+                  leading: const Icon(Icons.schedule_outlined),
+                  title: const Text('View schedule'),
+                  onTap: () {
+                    Navigator.of(context).pop();
+                    _handleOpenSchedule();
+                  },
+                ),
+                ListTile(
+                  leading: const Icon(Icons.flag_outlined),
+                  title: const Text('Set a new goal'),
+                  onTap: () {
+                    Navigator.of(context).pop();
+                    ScaffoldMessenger.of(this.context).showSnackBar(
+                      const SnackBar(
+                        content: Text('Goal settings coming soon.'),
+                      ),
+                    );
+                  },
+                ),
+              ],
+            ),
+          ),
+        );
+      },
     );
   }
 


### PR DESCRIPTION
## Summary
- add reusable pickers and inline feedback to the add schedule flow so users can choose workout, difficulty, reps, and weight before saving
- wire workout tracker and schedule surfaces to navigate to detail, schedule, and mark-done flows while exposing quick actions from the overflow menu
- enrich workout detail and exercise-step screens with favourite toggles, equipment/step summaries, start-workout navigation, and user feedback snackbars

## Testing
- dart format lib/view/workout_tracker/add_schedule_view.dart lib/view/workout_tracker/workout_tracker_view.dart lib/view/workout_tracker/workout_schedule_view.dart lib/view/workout_tracker/workour_detail_view.dart lib/view/workout_tracker/exercises_step_details.dart *(fails: command not found)*
- flutter format lib/view/workout_tracker/add_schedule_view.dart lib/view/workout_tracker/workout_tracker_view.dart lib/view/workout_tracker/workout_schedule_view.dart lib/view/workout_tracker/workour_detail_view.dart lib/view/workout_tracker/exercises_step_details.dart *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e4bf6b91cc833394c0f6830809909b